### PR TITLE
Update 2013-07-12-readings-in-distributed-systems.markdown

### DIFF
--- a/_posts/2013-07-12-readings-in-distributed-systems.markdown
+++ b/_posts/2013-07-12-readings-in-distributed-systems.markdown
@@ -180,7 +180,7 @@ requests][pull] or leave comments!
 [generals]: http://www.cs.cornell.edu/courses/cs614/2004sp/papers/lsp82.pdf
 [flp]: http://macs.citadel.edu/rudolphg/csci604/ImpossibilityofConsensus.pdf
 [treedoc]: http://hal.inria.fr/docs/00/44/59/75/PDF/icdcs09-treedoc.pdf
-[zab]: http://labs.yahoo.com/files/ladis08.pdf
+[zab]: https://pdfs.semanticscholar.org/f333/798a4bd5b415c6aa7c24ad1719d82de03163.pdf
 [computing]: http://dl.acm.org/citation.cfm?id=974938
 [blooml]: http://db.cs.berkeley.edu/papers/UCB-lattice-tr.pdf
 [dedalus]: http://db.cs.berkeley.edu/papers/datalog2011-dedalus.pdf


### PR DESCRIPTION
Just a head's up that there's a broken link on:
https://christophermeiklejohn.com/distributed/systems/2013/07/12/readings-in-distributed-systems.html
Here is the broken link:
http://labs.yahoo.com/files/ladis08.pdf

Look like these might be good replacements:
http://diyhpl.us/~bryan/papers2/distributed/distributed-systems/zab.totally-ordered-broadcast-protocol.2008.pdf
or 
https://pdfs.semanticscholar.org/f333/798a4bd5b415c6aa7c24ad1719d82de03163.pdf