### PR TITLE
Improve mobile reading experience

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -95,10 +95,14 @@ ul.posts span {
 .site {
   font-size: 100%;
   text-align: left;
-  width: 65em;
+  max-width: 65em;
   padding: 0px 10px 10px 10px;
   margin: 3em auto 3em;
   line-height: 1.5em;
+}
+
+.site .header {
+  margin-bottom: 2rem;
 }
 
 .site .header a {
@@ -108,7 +112,7 @@ ul.posts span {
 
 .site .header h1.title {
   display: inline-block;
-  margin-bottom: 2em;
+  margin-bottom: 0;
 }
 
 .site .header h1.title a {


### PR DESCRIPTION
Hi, I read your work on my phone a lot and the current layout is
restricted to 65em, which results in a lot of horizontal
scrolling. This commit changes it so that the max-width is still 65em,
but it will also scale to smaller devices. After making this change, I
also noticed that the navigation h1 tag looked a bit weird on smaller
sizes, so I moved the margin from the h1 to the navigation wrapping
.header element.

I tested the main page and a blog post on desktop chrome, android,
ipad pro, and iphone, but didn't check every post so there could be
code somewhere that "breaks out" of the layout and requires horizontal
scolling.

# Before (mobile)

![image](https://user-images.githubusercontent.com/551247/50047313-6d7c3980-0067-11e9-890e-3e6cc7c7070f.png)

# After (mobile)

![image](https://user-images.githubusercontent.com/551247/50047308-563d4c00-0067-11e9-8f4a-3324269b9f73.png)
