### PR TITLE
Blog growth: SEO, series chrome, RSS subscribe, Bluesky, subtitles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,14 @@
 name: Christopher Meiklejohn
-description: Christopher Meiklejohn
-url: http://christophermeiklejohn.com
+description: Notes on multi-agent systems, distributed computing, fault injection, and the engineering practice of shipping research. By Christopher Meiklejohn.
+short_description: Christopher Meiklejohn — notes on multi-agent systems, distributed computing, and shipping research.
+url: https://christophermeiklejohn.com
+author: Christopher Meiklejohn
+default_og_image: /me.jpg
+
+# Profile URLs across the web. Used for JSON-LD sameAs and the site nav.
+social:
+  github: https://github.com/cmeiklejohn
+  bluesky: https://bsky.app/profile/cmeik.bsky.social
+
 highlighter: rouge
 exclude: [vendor]

--- a/_data/series.yml
+++ b/_data/series.yml
@@ -1,0 +1,11 @@
+# Series metadata, keyed by the `series:` slug used in post frontmatter.
+#
+# Each series also has an ordered post list in `_data/{slug}_series.yml`
+# (e.g. `_data/mas_series.yml`), which is what the prev/next include
+# walks. This file holds only the series-level chrome.
+
+mas:
+  title: "Getting Up to Speed on Multi-Agent Systems"
+  short_title: "Getting Up to Speed on MAS"
+  landing_url: /series/multi-agent-systems/
+  description: "An eight-part series mapping the multi-agent LLM literature for readers coming in fresh. Two waves of research, one outside disruption, and the questions the field is still trying to answer."

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -1,0 +1,39 @@
+{%- comment -%}
+  "More on this topic" — shows up to 5 sibling posts that share the
+  current post's `group:` (the user's coarse topic field). Excludes the
+  current post and any other post in the same series, since those are
+  already linked via the series prev/next.
+
+  Renders nothing if there are no siblings, or if the current post has
+  no `group:` set.
+{%- endcomment -%}
+
+{%- if page.group -%}
+  {%- assign sibling_posts = site.posts | where: "group", page.group | sort: "date" | reverse -%}
+  {%- assign related = "" | split: "" -%}
+  {%- for p in sibling_posts -%}
+    {%- if p.url == page.url -%}{%- continue -%}{%- endif -%}
+    {%- if page.series and p.series == page.series -%}{%- continue -%}{%- endif -%}
+    {%- assign related = related | push: p -%}
+    {%- if related.size >= 5 -%}{%- break -%}{%- endif -%}
+  {%- endfor -%}
+
+  {%- if related.size > 0 -%}
+    <aside class="related-posts" aria-labelledby="related-heading">
+      <p id="related-heading" class="related-posts-label">More on this topic</p>
+      <ul class="related-posts-list">
+        {%- for p in related -%}
+          <li>
+            <a class="related-posts-link" href="{{ p.url }}">
+              <span class="related-posts-date">{{ p.date | date: "%b %-d, %Y" }}</span>
+              <span class="related-posts-title">{{ p.title }}</span>
+              {%- if p.subtitle -%}
+                <span class="related-posts-subtitle">{{ p.subtitle }}</span>
+              {%- endif -%}
+            </a>
+          </li>
+        {%- endfor -%}
+      </ul>
+    </aside>
+  {%- endif -%}
+{%- endif -%}

--- a/_includes/seo-meta.html
+++ b/_includes/seo-meta.html
@@ -1,0 +1,126 @@
+{%- comment -%}
+  SEO + social meta. Emits description, canonical, Open Graph, and Twitter
+  card tags for every page in the site.
+
+  Per-post / per-page overrides via frontmatter:
+    description:      one-line summary used for meta description + og + twitter
+    image:            absolute or root-relative image path; falls back to site default
+    image_card_type:  "summary" (default) or "summary_large_image" — set to the
+                      large variant only when you have a 1200x630-ish image
+{%- endcomment -%}
+
+{%- comment -%} ---- Title ---- {%- endcomment -%}
+{%- if page.title -%}
+  {%- assign meta_title = page.title -%}
+  {%- if page.subtitle -%}
+    {%- assign meta_title = meta_title | append: " · " | append: page.subtitle -%}
+  {%- endif -%}
+  {%- assign meta_full_title = meta_title | append: " | " | append: site.name -%}
+{%- else -%}
+  {%- assign meta_title = site.name -%}
+  {%- assign meta_full_title = site.name -%}
+{%- endif -%}
+
+{%- comment -%} ---- Description ---- {%- endcomment -%}
+{%- if page.description -%}
+  {%- assign meta_description = page.description -%}
+{%- elsif page.subtitle -%}
+  {%- assign meta_description = page.subtitle -%}
+{%- elsif page.excerpt -%}
+  {%- assign meta_description = page.excerpt | strip_html | strip_newlines | truncate: 200 -%}
+{%- else -%}
+  {%- assign meta_description = site.short_description | default: site.description -%}
+{%- endif -%}
+
+{%- comment -%} ---- Image ---- {%- endcomment -%}
+{%- if page.image -%}
+  {%- assign meta_image = page.image | absolute_url -%}
+{%- else -%}
+  {%- assign meta_image = site.default_og_image | default: "/me.jpg" | absolute_url -%}
+{%- endif -%}
+
+{%- comment -%} ---- Type ---- {%- endcomment -%}
+{%- if page.layout == "post" -%}
+  {%- assign meta_type = "article" -%}
+{%- else -%}
+  {%- assign meta_type = "website" -%}
+{%- endif -%}
+
+{%- comment -%} ---- Twitter card variant ---- {%- endcomment -%}
+{%- assign twitter_card = page.image_card_type | default: "summary" -%}
+
+<meta name="description" content="{{ meta_description | xml_escape }}">
+<link rel="canonical" href="{{ page.url | absolute_url }}">
+
+<meta property="og:title" content="{{ meta_title | xml_escape }}">
+<meta property="og:description" content="{{ meta_description | xml_escape }}">
+<meta property="og:type" content="{{ meta_type }}">
+<meta property="og:url" content="{{ page.url | absolute_url }}">
+<meta property="og:image" content="{{ meta_image }}">
+<meta property="og:site_name" content="{{ site.name | xml_escape }}">
+{%- if page.layout == "post" %}
+<meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">
+{%- if site.author %}
+<meta property="article:author" content="{{ site.author | xml_escape }}">
+{%- endif %}
+{%- endif %}
+
+<meta name="twitter:card" content="{{ twitter_card }}">
+<meta name="twitter:title" content="{{ meta_title | xml_escape }}">
+<meta name="twitter:description" content="{{ meta_description | xml_escape }}">
+<meta name="twitter:image" content="{{ meta_image }}">
+{%- if site.twitter_handle and site.twitter_handle != "" %}
+<meta name="twitter:site" content="{{ site.twitter_handle }}">
+<meta name="twitter:creator" content="{{ site.twitter_handle }}">
+{%- endif %}
+
+{%- comment -%} ---- JSON-LD structured data ---- {%- endcomment -%}
+{%- assign person_url = site.url -%}
+{%- capture same_as -%}
+{%- if site.social.github %}"{{ site.social.github }}"{% endif -%}
+{%- if site.social.bluesky %}{% if site.social.github %},{% endif %}"{{ site.social.bluesky }}"{% endif -%}
+{%- endcapture -%}
+{%- if page.layout == "post" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ page.url | absolute_url }}"
+  },
+  "headline": {{ meta_title | jsonify }},
+  "description": {{ meta_description | jsonify }},
+  "image": "{{ meta_image }}",
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  "dateModified": "{{ page.date | date_to_xmlschema }}",
+  "author": {
+    "@type": "Person",
+    "name": "{{ site.author | default: site.name }}",
+    "url": "{{ person_url }}"{% if same_as != "" %},
+    "sameAs": [{{ same_as }}]{% endif %}
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": "{{ site.author | default: site.name }}",
+    "url": "{{ person_url }}"
+  }
+}
+</script>
+{%- else %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": {{ site.name | jsonify }},
+  "url": "{{ site.url }}",
+  "description": {{ site.description | jsonify }},
+  "author": {
+    "@type": "Person",
+    "name": "{{ site.author | default: site.name }}",
+    "url": "{{ person_url }}"{% if same_as != "" %},
+    "sameAs": [{{ same_as }}]{% endif %}
+  }
+}
+</script>
+{%- endif %}

--- a/_includes/series-prev-next.html
+++ b/_includes/series-prev-next.html
@@ -1,0 +1,75 @@
+{%- comment -%}
+  Generic previous/next series navigation, rendered at the bottom of any
+  post that has `series: <slug>` in frontmatter.
+
+  Reads:
+    - site.data.series[<slug>]            — series-level metadata
+    - site.data[<slug>_series]            — ordered list of posts
+
+  Quietly renders nothing if the post isn't found in the ordered list,
+  so a stray `series: foo` in frontmatter won't blow up the build.
+{%- endcomment -%}
+
+{%- assign series_meta = site.data.series[page.series] -%}
+{%- assign series_data_key = page.series | append: "_series" -%}
+{%- assign series_list = site.data[series_data_key] -%}
+
+{%- assign current_index = -1 -%}
+{%- for entry in series_list -%}
+  {%- if entry.url == page.url -%}
+    {%- assign current_index = forloop.index0 -%}
+    {%- break -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- if current_index >= 0 -%}
+  {%- assign published_urls = site.posts | where: "series", page.series | map: "url" -%}
+  {%- assign total = series_list.size -%}
+  {%- assign part_num = current_index | plus: 1 -%}
+
+  <nav class="series-prev-next" aria-label="Series navigation">
+    <div class="series-prev-next-meta">
+      {%- if series_meta.landing_url -%}
+        <a href="{{ series_meta.landing_url }}">{{ series_meta.short_title | default: series_meta.title }}</a>
+      {%- else -%}
+        {{ series_meta.short_title | default: series_meta.title }}
+      {%- endif -%}
+      <span class="series-prev-next-meta-sep"> · </span>Part {{ part_num }} of {{ total }}
+    </div>
+    <div class="series-prev-next-row">
+      {%- if current_index > 0 -%}
+        {%- assign prev_index = current_index | minus: 1 -%}
+        {%- assign prev = series_list[prev_index] -%}
+        <a class="series-prev-next-card series-prev" href="{{ prev.url }}">
+          <span class="series-prev-next-direction">← Previous</span>
+          <span class="series-prev-next-title">{{ prev.title }}</span>
+        </a>
+      {%- else -%}
+        <span class="series-prev-next-card series-prev-next-empty" aria-hidden="true"></span>
+      {%- endif -%}
+
+      {%- assign next_index = current_index | plus: 1 -%}
+      {%- if next_index < total -%}
+        {%- assign next = series_list[next_index] -%}
+        {%- assign next_published = false -%}
+        {%- for u in published_urls -%}
+          {%- if u == next.url -%}{%- assign next_published = true -%}{%- break -%}{%- endif -%}
+        {%- endfor -%}
+        {%- if next_published -%}
+          <a class="series-prev-next-card series-next" href="{{ next.url }}">
+            <span class="series-prev-next-direction">Next →</span>
+            <span class="series-prev-next-title">{{ next.title }}</span>
+          </a>
+        {%- else -%}
+          <span class="series-prev-next-card series-next series-prev-next-pending">
+            <span class="series-prev-next-direction">Next →</span>
+            <span class="series-prev-next-title">{{ next.title }}</span>
+            <span class="series-prev-next-date">publishes {{ next.date | date: "%B %-d" }}</span>
+          </span>
+        {%- endif -%}
+      {%- else -%}
+        <span class="series-prev-next-card series-prev-next-empty" aria-hidden="true"></span>
+      {%- endif -%}
+    </div>
+  </nav>
+{%- endif -%}

--- a/_includes/subscribe.html
+++ b/_includes/subscribe.html
@@ -1,0 +1,13 @@
+{%- comment -%}
+  Subscribe block — RSS-only for now. When a newsletter service is added
+  later, this is the only file that needs to change.
+{%- endcomment -%}
+<aside class="subscribe" aria-labelledby="subscribe-heading">
+  <p id="subscribe-heading" class="subscribe-label">New posts</p>
+  <p class="subscribe-blurb">
+    No newsletter yet — the site has an RSS feed you can drop into Feedly, Inoreader, NetNewsWire, or any other reader.
+  </p>
+  <p class="subscribe-cta">
+    <a href="/feed.xml">Subscribe via RSS →</a>
+  </p>
+</aside>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,12 +13,7 @@
         </script>
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>{% if page.subtitle %}{{ page.title | xml_escape }} · {{ page.subtitle | xml_escape }} | {{ site.name | xml_escape }}{% elsif page.title %}{{ page.title | xml_escape }}{% else %}{{ site.name | xml_escape }}{% endif %}</title>
-        {% if page.layout == 'post' and page.subtitle %}
-        <meta name="description" content="{{ page.subtitle | xml_escape }}">
-        <meta property="og:title" content="{{ page.title | xml_escape }} · {{ page.subtitle | xml_escape }}">
-        <meta property="og:description" content="{{ page.subtitle | xml_escape }}">
-        <meta property="og:type" content="article">
-        {% endif %}
+        {% include seo-meta.html %}
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
         {% if page.refresh %}
         <meta http-equiv="refresh" content="0; url={{ page.refresh | xml_escape }}">
@@ -70,9 +65,16 @@
                 <a href="/teaching.html">teaching</a>
                 <a href="/publications.html">publications</a>
                 <a href="/meiklejohn-cv.pdf">curriculum vitae</a>
-                <a class="site-nav-github" href="https://github.com/cmeiklejohn" aria-label="GitHub (code)">
-                  <svg class="site-nav-github-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                {% if site.social.github %}
+                <a class="site-nav-icon site-nav-github" href="{{ site.social.github }}" aria-label="GitHub (code)">
+                  <svg class="site-nav-icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
                 </a>
+                {% endif %}
+                {% if site.social.bluesky %}
+                <a class="site-nav-icon site-nav-bluesky" href="{{ site.social.bluesky }}" aria-label="Bluesky">
+                  <svg class="site-nav-icon-svg" viewBox="0 0 600 530" aria-hidden="true" focusable="false"><path fill="currentColor" d="m135.7 44.3c66.7 50.1 138.4 151.7 164.7 206.2 26.3-54.5 98-156.1 164.7-206.2 48.1-36.1 126-64.1 126 24.7 0 17.7-10.2 148.9-16.1 170.2-20.7 74-96.1 92.9-163.2 81.5 117.2 19.9 147 86 82.7 152.1-122.2 125.7-175.7-31.6-189.4-71.9-2.5-7.3-3.7-10.8-3.7-7.8 0-3-1.2.5-3.7 7.8-13.7 40.3-67.2 197.6-189.4 71.9-64.3-66.1-34.5-132.2 82.7-152.1-67.1 11.4-142.5-7.5-163.2-81.5-5.9-21.3-16.1-152.5-16.1-170.2 0-88.8 77.9-60.8 126-24.7z"/></svg>
+                </a>
+                {% endif %}
               </nav>
             </header>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,4 +13,12 @@ layout: default
   <div id="post">
 {{ content }}
   </div>
+
+  {% if page.series %}
+    {% include series-prev-next.html %}
+  {% endif %}
+
+  {% include related-posts.html %}
+
+  {% include subscribe.html %}
 </article>

--- a/_posts/2026-04-09-the-structural-engineers-other-job.markdown
+++ b/_posts/2026-04-09-the-structural-engineers-other-job.markdown
@@ -1,6 +1,7 @@
 ---
 layout: post
 title:  "The Structural Engineer's Other Job"
+subtitle: "AI-generated code increasingly passes review and tests but ships half-working features. What humans have to check for instead."
 date:   2026-04-09 00:00:00 -0000
 group: ai
 categories: ai verification zabriskie agents

--- a/_posts/2026-04-14-opt-in-isnt-a-guardrail.markdown
+++ b/_posts/2026-04-14-opt-in-isnt-a-guardrail.markdown
@@ -1,6 +1,7 @@
 ---
 layout: post
 title:  "Opt-In Isn't a Guardrail"
+subtitle: "A CI gate I built to slow AI agents down passed every paperwork check, missed every real bug, and blocked the rollback during a production outage."
 date:   2026-04-14 00:00:00 -0000
 group: ai
 categories: ai zabriskie agents reliability caucus

--- a/_posts/2026-04-21-the-tax-on-the-happy-path.markdown
+++ b/_posts/2026-04-21-the-tax-on-the-happy-path.markdown
@@ -1,6 +1,7 @@
 ---
 layout: post
 title:  "The Tax on the Happy Path"
+subtitle: "What I learned by removing the elaborate CI gate I'd built to slow my AI agents down — after realizing it had never actually caught anything."
 date:   2026-04-21 00:00:00 -0000
 group: ai
 categories: ai zabriskie agents reliability caucus

--- a/_posts/2026-04-23-the-tribe-has-to-outlive-the-model.markdown
+++ b/_posts/2026-04-23-the-tribe-has-to-outlive-the-model.markdown
@@ -1,6 +1,7 @@
 ---
 layout: post
 title:  "The Tribe Has to Outlive the Model"
+subtitle: "Five model swaps in three weeks taught me the project's continuity lives in the humans and conventions around the agents, not the agents themselves."
 date:   2026-04-23 00:00:00 -0000
 group: ai
 categories: ai zabriskie agents reliability

--- a/css/main.css
+++ b/css/main.css
@@ -476,7 +476,7 @@ code {
   outline-offset: 2px;
 }
 
-.site-nav-github {
+.site-nav-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -484,11 +484,11 @@ code {
   line-height: 1;
 }
 
-.site-nav-github:hover {
+.site-nav-icon:hover {
   color: var(--link);
 }
 
-.site-nav-github-icon {
+.site-nav-icon-svg {
   display: block;
   width: 1.15rem;
   height: 1.15rem;
@@ -1302,4 +1302,174 @@ html {
 
 .home-series-section ul.posts li {
   border-bottom-color: var(--border-strong);
+}
+
+/*****************************************************************************/
+/* Related posts ("More on this topic") footer
+/*****************************************************************************/
+
+.related-posts {
+  margin: 2.5rem 0 1rem;
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--border);
+  font-family: var(--font-ui);
+}
+
+.related-posts-label {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--fg-muted);
+  margin: 0 0 0.85rem;
+}
+
+.related-posts-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+
+.related-posts-link {
+  display: block;
+  padding: 0.75rem 1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--fg);
+  transition: border-color 120ms ease;
+}
+
+.related-posts-link:hover {
+  border-color: var(--brand);
+}
+
+.related-posts-date {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--fg-muted);
+  letter-spacing: 0.5px;
+  margin-bottom: 0.15rem;
+}
+
+.related-posts-title {
+  display: block;
+  font-family: var(--font-text);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--fg-heading);
+  line-height: 1.3;
+}
+
+.related-posts-link:hover .related-posts-title {
+  color: var(--link-hover);
+}
+
+.related-posts-subtitle {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--fg-muted);
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+/*****************************************************************************/
+/* Email subscribe (Buttondown embed)
+/*****************************************************************************/
+
+.subscribe {
+  margin: 2.5rem 0 1rem;
+  padding: 1.25rem 1.4rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-family: var(--font-ui);
+}
+
+.subscribe-label {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--brand);
+  margin: 0 0 0.35rem;
+}
+
+.subscribe-blurb {
+  margin: 0 0 0.85rem;
+  color: var(--fg-muted);
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.subscribe-cta {
+  margin: 0;
+  font-size: 0.98rem;
+  font-weight: 600;
+}
+
+.subscribe-cta a {
+  color: var(--brand);
+  text-decoration: none;
+}
+
+.subscribe-cta a:hover {
+  color: var(--link-hover);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.subscribe-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.subscribe-form input[type="email"] {
+  flex: 1;
+  min-width: 0;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-ui);
+  font-size: 0.95rem;
+  line-height: 1.2;
+}
+
+.subscribe-form input[type="email"]:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px var(--selection-bg);
+}
+
+.subscribe-form button {
+  padding: 0.6rem 1.1rem;
+  border: 1px solid var(--brand);
+  border-radius: 5px;
+  background: var(--brand);
+  color: var(--bg);
+  font-family: var(--font-ui);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.subscribe-form button:hover {
+  background: var(--link-hover);
+  border-color: var(--link-hover);
+}
+
+@media (max-width: 480px) {
+  .subscribe-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/css/mas-series.css
+++ b/css/mas-series.css
@@ -384,3 +384,224 @@
   font-size: 0.8em;
   margin-left: 0.25rem;
 }
+
+/* -------------------------------------------------------------------------
+   Generic series chrome — prev/next at end of post, plus landing page list
+   ------------------------------------------------------------------------- */
+
+.series-prev-next {
+  margin: 2.5rem 0 1rem;
+  font-family: var(--font-ui);
+}
+
+.series-prev-next-meta {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--fg-muted);
+  margin-bottom: 0.55rem;
+}
+
+.series-prev-next-meta a {
+  color: var(--fg-muted);
+  text-decoration: underline;
+  text-decoration-color: var(--border-strong);
+  text-underline-offset: 3px;
+}
+
+.series-prev-next-meta a:hover {
+  color: var(--link-hover);
+  text-decoration-color: var(--link-hover);
+}
+
+.series-prev-next-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.series-prev-next-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.85rem 1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--fg);
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.series-prev-next-card:hover {
+  border-color: var(--brand);
+}
+
+.series-prev-next-card.series-next {
+  text-align: right;
+}
+
+.series-prev-next-card.series-prev-next-empty {
+  background: transparent;
+  border: 1px dashed var(--border);
+  visibility: hidden;
+}
+
+.series-prev-next-card.series-prev-next-pending {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.series-prev-next-direction {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--fg-muted);
+}
+
+.series-prev-next-title {
+  font-size: 0.95rem;
+  color: var(--fg-heading);
+  font-weight: 600;
+}
+
+.series-prev-next-card:hover .series-prev-next-title {
+  color: var(--link-hover);
+}
+
+.series-prev-next-card.series-prev-next-pending .series-prev-next-title {
+  color: var(--fg-muted);
+}
+
+.series-prev-next-date {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+  margin-top: 0.15rem;
+}
+
+@media (max-width: 600px) {
+  .series-prev-next-row {
+    grid-template-columns: 1fr;
+  }
+  .series-prev-next-card.series-next {
+    text-align: left;
+  }
+  .series-prev-next-card.series-prev-next-empty {
+    display: none;
+  }
+}
+
+/* -------------------------------------------------------------------------
+   Series landing page
+   ------------------------------------------------------------------------- */
+
+.series-landing-lead {
+  font-size: 1.15rem;
+  line-height: 1.55;
+  color: var(--fg-heading);
+  margin: 1rem 0 1.25rem;
+}
+
+.series-landing-meta {
+  font-family: var(--font-ui);
+  color: var(--fg-muted);
+  margin: 0 0 1rem;
+  line-height: 1.55;
+}
+
+.series-landing-meta strong {
+  color: var(--fg-heading);
+}
+
+.series-landing-list {
+  margin: 2rem 0 1.5rem;
+}
+
+.series-landing-list ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: series-landing;
+}
+
+.series-landing-item {
+  counter-increment: series-landing;
+  margin-bottom: 0.55rem;
+}
+
+.series-landing-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0.85rem 2.6rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--fg);
+  position: relative;
+  transition: border-color 120ms ease;
+}
+
+.series-landing-link::before {
+  content: counter(series-landing, decimal-leading-zero);
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--fg-muted);
+  letter-spacing: 0.5px;
+}
+
+a.series-landing-link:hover {
+  border-color: var(--brand);
+}
+
+a.series-landing-link:hover .series-landing-title {
+  color: var(--link-hover);
+}
+
+.series-landing-title {
+  font-family: var(--font-text);
+  font-size: 1.02rem;
+  font-weight: 600;
+  color: var(--fg-heading);
+  flex: 1;
+}
+
+.series-landing-date {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+
+.series-landing-pending .series-landing-link {
+  opacity: 0.7;
+}
+
+.series-landing-pending .series-landing-title {
+  color: var(--fg-muted);
+  font-weight: 500;
+}
+
+.series-landing-back {
+  font-family: var(--font-ui);
+  color: var(--fg-muted);
+  margin-top: 2rem;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  .series-landing-link {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+}

--- a/feed.xml
+++ b/feed.xml
@@ -8,7 +8,7 @@ layout: null
 		<description>{{ site.description }}</description>
 		<link>{{ site.url }}</link>
 		<atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
-		{% for post in site.posts limit:10 %}
+		{% for post in site.posts limit:50 %}
 			<item>
 				<title>{{ post.title | xml_escape }}{% if post.subtitle %} · {{ post.subtitle | xml_escape }}{% endif %}</title>
 				<description>{{ post.content | xml_escape }}</description>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Christopher Meiklejohn
+description: "Christopher Meiklejohn — Ph.D., Software Engineering (CMU). Notes on multi-agent systems, distributed computing, fault injection, and the engineering practice of shipping research."
 ---
 
 <div id="home">
@@ -11,8 +12,8 @@ title: Christopher Meiklejohn
   </p>
 
   <section class="archive-section home-series-section" aria-labelledby="home-series-heading">
-    <h2 id="home-series-heading" class="home-section-title archive-section-heading">Series · Getting Up to Speed on Multi-Agent Systems</h2>
-    <p class="archive-section-intro">A short series mapping the multi-agent LLM literature for readers coming in fresh. Published over the next week and a half.</p>
+    <h2 id="home-series-heading" class="home-section-title archive-section-heading"><a href="/series/multi-agent-systems/">Series · Getting Up to Speed on Multi-Agent Systems</a></h2>
+    <p class="archive-section-intro">A short series mapping the multi-agent LLM literature for readers coming in fresh. Published over the next week and a half. <a href="/series/multi-agent-systems/">Series overview →</a></p>
     <ul class="posts">
       {% assign mas_posts = site.posts | where: "series", "mas" | sort: "date" %}
       {% for post in mas_posts %}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,8 @@
+---
+layout: null
+permalink: /robots.txt
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ site.url }}/sitemap.xml

--- a/series/multi-agent-systems.md
+++ b/series/multi-agent-systems.md
@@ -1,0 +1,48 @@
+---
+layout: page
+title: "Getting Up to Speed on Multi-Agent Systems"
+description: "An eight-part series mapping the multi-agent LLM literature for readers coming in fresh — two waves of research, one outside disruption, and the questions the field is still trying to answer."
+permalink: /series/multi-agent-systems/
+series: mas
+---
+
+<p class="series-landing-lead">An eight-part series mapping the multi-agent LLM literature for readers coming in fresh. Two waves of research, one outside disruption that reshaped both, and the questions the field is still trying to answer.</p>
+
+<p class="series-landing-meta">
+  <strong>Who this is for:</strong> you already ship or evaluate LLM agents (tools, long context, basic eval loops) and want the <em>research</em> landscape in view. This is not an on-ramp to transformers or prompting fundamentals.
+</p>
+
+<p class="series-landing-meta">
+  Read straight through, or jump in wherever the title pulls you. The first two parts set up vocabulary; parts 3–6 walk through specific clusters of papers; parts 7–8 zoom out to benchmarks and what's still open.
+</p>
+
+<section class="series-landing-list" aria-label="Series posts">
+  {%- assign published_urls = site.posts | where: "series", "mas" | map: "url" -%}
+  <ol>
+    {%- for entry in site.data.mas_series -%}
+      {%- assign is_published = false -%}
+      {%- for u in published_urls -%}
+        {%- if u == entry.url -%}{%- assign is_published = true -%}{%- break -%}{%- endif -%}
+      {%- endfor -%}
+      <li class="series-landing-item{% unless is_published %} series-landing-pending{% endunless %}">
+        {%- if is_published -%}
+          <a href="{{ entry.url }}" class="series-landing-link">
+            <span class="series-landing-title">{{ entry.title }}</span>
+            <span class="series-landing-date">{{ entry.date | date: "%B %-d, %Y" }}</span>
+          </a>
+        {%- else -%}
+          <span class="series-landing-link series-landing-link-pending">
+            <span class="series-landing-title">{{ entry.title }}</span>
+            <span class="series-landing-date">publishes {{ entry.date | date: "%B %-d, %Y" }}</span>
+          </span>
+        {%- endif -%}
+      </li>
+    {%- endfor -%}
+  </ol>
+</section>
+
+{% include subscribe.html %}
+
+<p class="series-landing-back">
+  <a href="/">← Home</a> · <a href="/archive.html">Full archive →</a>
+</p>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,45 @@
+---
+layout: null
+permalink: /sitemap.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>{{ site.url }}/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>{{ site.url }}/archive.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>{{ site.url }}/research.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>{{ site.url }}/teaching.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>{{ site.url }}/publications.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>{{ site.url }}/series/multi-agent-systems/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  {% for post in site.posts %}
+  <url>
+    <loc>{{ site.url }}{{ post.url }}</loc>
+    <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
## Summary

A coherent pass to make the blog more discoverable for new readers.

- **Series chrome** — new `/series/multi-agent-systems/` landing page; auto prev/next nav at the bottom of any post with `series:` frontmatter; data-driven so future series only need a `_data/{slug}_series.yml` + entry in `_data/series.yml`
- **SEO + social** — full OG + Twitter card meta on every page; BlogPosting / WebSite JSON-LD with sameAs to GitHub + Bluesky; new `sitemap.xml` and `robots.txt`; bumped `_config.yml` to https and added author/description/social
- **Reader retention** — "More on this topic" footer (siblings by `group:`, excludes same-series); RSS-only subscribe block at the bottom of every post and on the series landing
- **Distribution** — Bluesky icon next to GitHub in the nav; `feed.xml` bumped from 10 → 50 items so platforms like Substack can pull historical posts on first import
- **Subtitles** for the four aphoristic recent titles (The Structural Engineer's Other Job, Opt-In Isn't a Guardrail, The Tax on the Happy Path, The Tribe Has to Outlive the Model)

## Test plan

- [ ] After deploy, hit https://christophermeiklejohn.com/feed.xml and confirm 50 items
- [ ] Validate sitemap at https://christophermeiklejohn.com/sitemap.xml
- [ ] Drop a post URL into https://www.opengraph.xyz/ to confirm OG cards unfurl
- [ ] Drop a post URL into https://search.google.com/test/rich-results to confirm BlogPosting JSON-LD parses
- [ ] Visit `/series/multi-agent-systems/` to confirm landing renders
- [ ] Visit any series post and scroll to the bottom — verify prev/next + related posts + subscribe block
- [ ] Confirm Bluesky butterfly icon appears next to GitHub in the header

## Known pre-existing issue (not addressed in this PR)

Part 1 of the MAS series has a date/URL drift: frontmatter says `2026-04-24 06:00:00 -0000` which Jekyll renders to `/2026/04/23/` in local time. `_data/mas_series.yml` says `/04/24/`. Result: in series navigation Part 1 always reads "publishes April 24" even though it's published. Fixable by changing the post's frontmatter time to `12:00:00 UTC` and updating both the filename and the data file URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)