### PR TITLE
Subscribe block on home + archive, plus Bluesky link

### DIFF
--- a/_includes/subscribe.html
+++ b/_includes/subscribe.html
@@ -5,9 +5,9 @@
 <aside class="subscribe" aria-labelledby="subscribe-heading">
   <p id="subscribe-heading" class="subscribe-label">New posts</p>
   <p class="subscribe-blurb">
-    No newsletter yet — the site has an RSS feed you can drop into Feedly, Inoreader, NetNewsWire, or any other reader.
+    No newsletter yet — the site has an RSS feed you can drop into Feedly, Inoreader, NetNewsWire, or any other reader. I post on Bluesky too.
   </p>
   <p class="subscribe-cta">
-    <a href="/feed.xml">Subscribe via RSS →</a>
+    <a href="/feed.xml">Subscribe via RSS →</a>{% if site.social.bluesky %} <span class="subscribe-cta-sep">·</span> <a href="{{ site.social.bluesky }}">Follow on Bluesky →</a>{% endif %}
   </p>
 </aside>

--- a/archive.html
+++ b/archive.html
@@ -193,4 +193,6 @@ title: Blog archive — Christopher Meiklejohn
       {% endfor %}
     </ul>
   </section>
+
+  {% include subscribe.html %}
 </div>

--- a/index.html
+++ b/index.html
@@ -36,4 +36,6 @@ description: "Christopher Meiklejohn — Ph.D., Software Engineering (CMU). Note
   <p class="home-archive-cta">
     <a href="/archive.html">Full archive by topic →</a>
   </p>
+
+  {% include subscribe.html %}
 </div>


### PR DESCRIPTION
## Summary

The subscribe chrome was only rendering on posts and the series landing. This was a real oversight — the home page is the most-visited page and had no follow CTA at all.

- Add `{% include subscribe.html %}` to [index.html](index.html) (after the recent-posts list)
- Add the same to [archive.html](archive.html) (after the General section)
- [_includes/subscribe.html](_includes/subscribe.html): include a Bluesky link alongside the RSS link, conditional on `site.social.bluesky` being set

## Test plan

- [ ] Confirm home page now shows "New posts" subscribe block at the bottom
- [ ] Confirm archive page shows the same
- [ ] Confirm Bluesky link is present alongside RSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)