### PR TITLE
Bump Bluesky social URL to verified handle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ default_og_image: /me.jpg
 # Profile URLs across the web. Used for JSON-LD sameAs and the site nav.
 social:
   github: https://github.com/cmeiklejohn
-  bluesky: https://bsky.app/profile/cmeik.bsky.social
+  bluesky: https://bsky.app/profile/christophermeiklejohn.com
 
 highlighter: rouge
 exclude: [vendor, scripts]


### PR DESCRIPTION
Same DID, new canonical URL after domain verification.