### PR TITLE
Bluesky comments rendered on every shared post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,10 @@ social:
   github: https://github.com/cmeiklejohn
   bluesky: https://bsky.app/profile/christophermeiklejohn.com
 
+# Bluesky DID — used by the bluesky-comments embed to construct at:// URIs
+# from the bsky.app URLs stored in _data/bluesky_log.yml.
+bluesky_did: did:plc:rz6tddfmmh2c6jind64mc6lw
+
 highlighter: rouge
 exclude: [vendor, scripts]
 include:

--- a/_includes/bluesky-comments.html
+++ b/_includes/bluesky-comments.html
@@ -1,0 +1,34 @@
+{%- comment -%}
+  Bluesky comments — renders the thread of replies to a Bluesky post that
+  shared this blog post.
+
+  Looks up the bluesky_url stored in _data/bluesky_log.yml (under
+  shared.{page.url}.bluesky_url), extracts the rkey, and builds an at://
+  URI using site.bluesky_did. Client-side JS (assets/js/bluesky-comments.js)
+  fetches the thread from public.api.bsky.app and renders replies inline.
+
+  Renders nothing if the post hasn't been shared on Bluesky yet.
+{%- endcomment -%}
+
+{%- assign bsky_log = site.data.bluesky_log.shared[page.url] -%}
+{%- if bsky_log and bsky_log.bluesky_url and site.bluesky_did -%}
+  {%- assign rkey = bsky_log.bluesky_url | split: "/post/" | last -%}
+  {%- assign bsky_at_uri = "at://" | append: site.bluesky_did | append: "/app.bsky.feed.post/" | append: rkey -%}
+  <section
+    class="bsky-comments"
+    aria-labelledby="bsky-comments-heading"
+    data-bsky-uri="{{ bsky_at_uri }}"
+    data-bsky-url="{{ bsky_log.bluesky_url }}"
+  >
+    <header class="bsky-comments-header">
+      <h2 id="bsky-comments-heading" class="bsky-comments-heading">Discussion on Bluesky</h2>
+      <p class="bsky-comments-subhead">
+        Replies to <a href="{{ bsky_log.bluesky_url }}" rel="external">this post on Bluesky</a> appear below. Reply there to join the conversation.
+      </p>
+    </header>
+    <div class="bsky-comments-body">
+      <p class="bsky-comments-loading">Loading discussion…</p>
+    </div>
+  </section>
+  <script src="/assets/js/bluesky-comments.js" defer></script>
+{%- endif -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -22,5 +22,7 @@ layout: default
 
   {% include related-posts.html %}
 
+  {% include bluesky-comments.html %}
+
   {% include subscribe.html %}
 </article>

--- a/assets/js/bluesky-comments.js
+++ b/assets/js/bluesky-comments.js
@@ -1,0 +1,237 @@
+/**
+ * Bluesky comments — fetches a post's reply thread from the public Bluesky
+ * AppView and renders it under the matching blog post.
+ *
+ * Activated by the presence of a `<section class="bsky-comments">` element
+ * with `data-bsky-uri="at://..."` (provided by _includes/bluesky-comments.html).
+ *
+ * No auth required; the AppView serves public threads anonymously. If the
+ * fetch fails (offline, rate limit, post deleted), we fall back to a
+ * "View on Bluesky" link.
+ */
+(function () {
+  "use strict";
+
+  var APPVIEW = "https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread";
+
+  function $(tag, attrs, children) {
+    var el = document.createElement(tag);
+    if (attrs) {
+      Object.keys(attrs).forEach(function (k) {
+        if (k === "class") el.className = attrs[k];
+        else if (k === "text") el.textContent = attrs[k];
+        else el.setAttribute(k, attrs[k]);
+      });
+    }
+    (children || []).forEach(function (c) {
+      if (c) el.appendChild(c);
+    });
+    return el;
+  }
+
+  function escapeHtml(s) {
+    return (s || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function linkifyText(text, facets) {
+    // Bluesky text uses byte offsets in facets. Sort by byteStart, walk the
+    // string, emit links for facet ranges and plain text for the rest.
+    if (!facets || !facets.length) return escapeHtml(text);
+    var encoder = new TextEncoder();
+    var bytes = encoder.encode(text);
+    var sorted = facets.slice().sort(function (a, b) {
+      return a.index.byteStart - b.index.byteStart;
+    });
+    var pieces = [];
+    var cursor = 0;
+    sorted.forEach(function (facet) {
+      if (facet.index.byteStart > cursor) {
+        pieces.push(escapeHtml(new TextDecoder().decode(bytes.slice(cursor, facet.index.byteStart))));
+      }
+      var slice = new TextDecoder().decode(bytes.slice(facet.index.byteStart, facet.index.byteEnd));
+      var feature = (facet.features || [])[0] || {};
+      if (feature.$type === "app.bsky.richtext.facet#link") {
+        pieces.push(
+          '<a href="' + escapeHtml(feature.uri) + '" rel="external nofollow">' + escapeHtml(slice) + "</a>"
+        );
+      } else if (feature.$type === "app.bsky.richtext.facet#mention") {
+        pieces.push(
+          '<a href="https://bsky.app/profile/' + escapeHtml(feature.did) + '" rel="external">' + escapeHtml(slice) + "</a>"
+        );
+      } else if (feature.$type === "app.bsky.richtext.facet#tag") {
+        pieces.push(escapeHtml(slice));
+      } else {
+        pieces.push(escapeHtml(slice));
+      }
+      cursor = facet.index.byteEnd;
+    });
+    if (cursor < bytes.length) {
+      pieces.push(escapeHtml(new TextDecoder().decode(bytes.slice(cursor))));
+    }
+    return pieces.join("").replace(/\n/g, "<br>");
+  }
+
+  function relativeTime(iso) {
+    var t = new Date(iso).getTime();
+    if (isNaN(t)) return "";
+    var diff = (Date.now() - t) / 1000;
+    if (diff < 60) return "just now";
+    if (diff < 3600) return Math.floor(diff / 60) + "m ago";
+    if (diff < 86400) return Math.floor(diff / 3600) + "h ago";
+    if (diff < 86400 * 30) return Math.floor(diff / 86400) + "d ago";
+    return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+  }
+
+  function postUrl(uri, handle) {
+    var rkey = uri.split("/").pop();
+    return "https://bsky.app/profile/" + handle + "/post/" + rkey;
+  }
+
+  function renderReply(reply, depth) {
+    if (!reply || reply.$type !== "app.bsky.feed.defs#threadViewPost") return null;
+    var post = reply.post;
+    if (!post || !post.author) return null;
+
+    var author = post.author;
+    var record = post.record || {};
+    var handle = author.handle || "unknown";
+    var displayName = author.displayName || handle;
+    var avatar = author.avatar;
+
+    var avatarEl = avatar
+      ? $("img", { class: "bsky-comment-avatar", src: avatar, alt: "", loading: "lazy", width: "36", height: "36" })
+      : $("span", { class: "bsky-comment-avatar bsky-comment-avatar-fallback", "aria-hidden": "true" });
+
+    var nameEl = $("a", {
+      class: "bsky-comment-name",
+      href: "https://bsky.app/profile/" + handle,
+      rel: "external",
+      text: displayName,
+    });
+
+    var handleEl = $("span", { class: "bsky-comment-handle", text: "@" + handle });
+
+    var timeEl = $("a", {
+      class: "bsky-comment-time",
+      href: postUrl(post.uri, handle),
+      rel: "external",
+      title: record.createdAt || "",
+      text: relativeTime(record.createdAt),
+    });
+
+    var headerEl = $("div", { class: "bsky-comment-header" }, [nameEl, handleEl, timeEl]);
+
+    var bodyEl = $("div", { class: "bsky-comment-body" });
+    bodyEl.innerHTML = linkifyText(record.text || "", record.facets);
+
+    var metaPieces = [];
+    if (post.likeCount) metaPieces.push((post.likeCount === 1 ? "1 like" : post.likeCount + " likes"));
+    if (post.repostCount) metaPieces.push((post.repostCount === 1 ? "1 repost" : post.repostCount + " reposts"));
+    if (post.replyCount) metaPieces.push((post.replyCount === 1 ? "1 reply" : post.replyCount + " replies"));
+    var metaEl = metaPieces.length
+      ? $("div", { class: "bsky-comment-meta", text: metaPieces.join(" · ") })
+      : null;
+
+    var children = [headerEl, bodyEl];
+    if (metaEl) children.push(metaEl);
+
+    var commentEl = $("article", { class: "bsky-comment bsky-comment-depth-" + depth }, [
+      $("div", { class: "bsky-comment-avatar-wrap" }, [avatarEl]),
+      $("div", { class: "bsky-comment-content" }, children),
+    ]);
+
+    var nestedReplies = (reply.replies || [])
+      .map(function (r) { return renderReply(r, depth + 1); })
+      .filter(Boolean);
+
+    if (nestedReplies.length) {
+      var nestedEl = $("div", { class: "bsky-comment-replies" }, nestedReplies);
+      commentEl.appendChild(nestedEl);
+    }
+
+    return commentEl;
+  }
+
+  function renderThread(section, thread, originalUrl) {
+    var body = section.querySelector(".bsky-comments-body");
+    body.innerHTML = "";
+
+    var post = thread && thread.post;
+    var likeCount = post ? post.likeCount || 0 : 0;
+    var repostCount = post ? post.repostCount || 0 : 0;
+    var replies = (thread && thread.replies) || [];
+
+    if (likeCount || repostCount) {
+      var summaryParts = [];
+      if (likeCount) summaryParts.push(likeCount === 1 ? "1 like" : likeCount + " likes");
+      if (repostCount) summaryParts.push(repostCount === 1 ? "1 repost" : repostCount + " reposts");
+      var summary = $("p", { class: "bsky-comments-summary", text: summaryParts.join(" · ") });
+      body.appendChild(summary);
+    }
+
+    if (!replies.length) {
+      var empty = $("p", { class: "bsky-comments-empty" }, [
+        document.createTextNode("No replies yet — "),
+        $("a", { href: originalUrl, rel: "external", text: "be the first to reply on Bluesky" }),
+        document.createTextNode("."),
+      ]);
+      body.appendChild(empty);
+      return;
+    }
+
+    var list = $("div", { class: "bsky-comments-list" },
+      replies.map(function (r) { return renderReply(r, 0); }).filter(Boolean));
+    body.appendChild(list);
+
+    var footer = $("p", { class: "bsky-comments-footer" }, [
+      $("a", { href: originalUrl, rel: "external", text: "View full thread on Bluesky →" }),
+    ]);
+    body.appendChild(footer);
+  }
+
+  function renderError(section, originalUrl) {
+    var body = section.querySelector(".bsky-comments-body");
+    body.innerHTML = "";
+    var p = $("p", { class: "bsky-comments-error" }, [
+      document.createTextNode("Couldn't load the thread. "),
+      $("a", { href: originalUrl, rel: "external", text: "View on Bluesky →" }),
+    ]);
+    body.appendChild(p);
+  }
+
+  function loadOne(section) {
+    var uri = section.getAttribute("data-bsky-uri");
+    var url = section.getAttribute("data-bsky-url");
+    if (!uri) return;
+
+    var endpoint = APPVIEW + "?uri=" + encodeURIComponent(uri) + "&depth=6";
+    fetch(endpoint, { headers: { Accept: "application/json" } })
+      .then(function (r) {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        if (!data || !data.thread) throw new Error("malformed thread");
+        renderThread(section, data.thread, url);
+      })
+      .catch(function () {
+        renderError(section, url);
+      });
+  }
+
+  function init() {
+    var sections = document.querySelectorAll(".bsky-comments");
+    Array.prototype.forEach.call(sections, loadOne);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/css/main.css
+++ b/css/main.css
@@ -1451,6 +1451,200 @@ html {
 }
 
 /*****************************************************************************/
+/* Bluesky comments — replies to the Bluesky post that shared this article
+/*****************************************************************************/
+
+.bsky-comments {
+  margin: 2.5rem 0 1rem;
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--border);
+  font-family: var(--font-ui);
+}
+
+.bsky-comments-header {
+  margin-bottom: 1.1rem;
+}
+
+.bsky-comments-heading {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--brand);
+  margin: 0 0 0.4rem;
+}
+
+.bsky-comments-subhead {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.bsky-comments-loading,
+.bsky-comments-empty,
+.bsky-comments-error {
+  color: var(--fg-muted);
+  font-size: 0.92rem;
+  font-style: italic;
+  margin: 0.75rem 0 0;
+}
+
+.bsky-comments-summary {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--fg-muted);
+  margin: 0 0 0.85rem;
+}
+
+.bsky-comments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+}
+
+.bsky-comment {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 0.65rem;
+  padding: 0.7rem 0.85rem 0.7rem 0.7rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.bsky-comment-avatar-wrap {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.bsky-comment-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: block;
+  background: var(--bg);
+  flex-shrink: 0;
+}
+
+.bsky-comment-avatar.bsky-comment-avatar-fallback {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+}
+
+.bsky-comment-content {
+  min-width: 0;
+}
+
+.bsky-comment-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-bottom: 0.25rem;
+  font-size: 0.88rem;
+}
+
+.bsky-comment-name {
+  font-weight: 600;
+  color: var(--fg-heading);
+  text-decoration: none;
+}
+
+.bsky-comment-name:hover {
+  color: var(--link-hover);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.bsky-comment-handle {
+  color: var(--fg-muted);
+  font-size: 0.82rem;
+}
+
+.bsky-comment-time {
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  text-decoration: none;
+  margin-left: auto;
+}
+
+.bsky-comment-time:hover {
+  text-decoration: underline;
+}
+
+.bsky-comment-body {
+  color: var(--fg);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.bsky-comment-body a {
+  color: var(--link);
+}
+
+.bsky-comment-meta {
+  margin-top: 0.45rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--fg-muted);
+}
+
+.bsky-comment-replies {
+  grid-column: 2;
+  margin-top: 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  border-left: 2px solid var(--border);
+  padding-left: 0.85rem;
+}
+
+.bsky-comment-replies .bsky-comment {
+  /* Nested replies use a flatter look. */
+  background: transparent;
+  border: 1px solid var(--border);
+  padding: 0.6rem 0.7rem 0.6rem 0.6rem;
+}
+
+.bsky-comments-footer {
+  margin: 1rem 0 0;
+  font-size: 0.88rem;
+}
+
+.bsky-comments-footer a {
+  color: var(--brand);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.bsky-comments-footer a:hover {
+  color: var(--link-hover);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+@media (max-width: 600px) {
+  .bsky-comment-time {
+    margin-left: 0;
+    flex-basis: 100%;
+  }
+  .bsky-comment-replies {
+    padding-left: 0.6rem;
+  }
+}
+
+/*****************************************************************************/
 /* Email subscribe (Buttondown embed)
 /*****************************************************************************/
 


### PR DESCRIPTION
## Summary

Closes the loop between the blog and Bluesky: posts that have been shared on Bluesky (tracked in \`_data/bluesky_log.yml\`) now render their reply thread inline at the bottom of the article.

- Anonymous public-API fetch (no auth, no SDK)
- Avatars, handles, relative timestamps, link facets, like/repost/reply counts
- Graceful fallback to "View on Bluesky →" if the fetch fails
- Renders nothing if a post hasn't been shared yet — zero overhead for unshared posts

## Test plan

- [ ] Visit https://christophermeiklejohn.com/ai/agents/mas-series/2026/04/24/mas-series-01-the-landscape.html and scroll to the bottom — should see "Discussion on Bluesky" with the like count and "No replies yet" empty state
- [ ] Same for /ai/zabriskie/community/2026/03/08/why-im-building-zabriskie.html
- [ ] Reply to one of the Bluesky posts → reload the blog post → reply renders inline
- [ ] Visit a post that hasn't been shared on Bluesky — no Bluesky comments section renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)