### PR TITLE
Rift: fix publish date + add basement summers vignette

### DIFF
--- a/_posts/2026-05-03-rift.markdown
+++ b/_posts/2026-05-03-rift.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Rift"
 subtitle: "For thirty years I programmed with Phish on, every day. In 2026, the music is out of phase with the work."
-date:   2026-05-03 13:00:00 -0700
+date:   2026-05-03 02:00:00 -0700
 group: ai
 categories: ai personal phish flow agents
 ---


### PR DESCRIPTION
## Summary

Two changes to the merged Rift post (#66):

1. **Date fix.** Original date was `2026-05-03 13:00:00 -0700` (1pm PDT). At time of merge it was 3am PDT, so Jekyll's default `future: false` was hiding the post. Backed down to `02:00:00 -0700` so it's in the past and after the click-the-button post in ordering.
2. **Content add.** New vignette in section 3: "I spent summers in the basement, much to my parents' chagrin, programming computers and listening to Phish. While other kids were outside, I was downstairs at the keyboard with a show on. That was June, July, and August." Slots in before the existing "free Friday night" repetition so the abstract list has concrete grounding first.

## Evidence

Two-line front-matter / prose edits to `_posts/2026-05-03-rift.markdown`. No structural change.

## Pre-merge checklist

### Build & Test
- [ ] `cd backend && go build ./...` — N/A (Jekyll blog)
- [ ] All E2E tests pass — N/A (Jekyll blog)
- [ ] Backend server restarted — N/A
- [ ] Screenshot — N/A (markdown post)

### Migrations (if applicable)
- [ ] N/A

### SDUI & Routing (if applicable)
- [ ] N/A

### Process
- [x] Branch is up to date with `origin/master`
- [x] No direct push to main — this is a PR
- [ ] CI checks pass
- [ ] Incident logged — N/A
- [ ] Changelog entry — N/A

Note: Zabriskie PR template hook fires on this even though it's the blog repo. Sections marked N/A.