### PR TITLE
Restore MAS series homepage link

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1416,18 +1416,27 @@ html {
   border-radius: 0 6px 6px 0;
   padding: 0.65rem 1rem;
   margin: 0 0 2rem;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
   align-items: baseline;
-  gap: 0.4rem 0.55rem;
+  gap: 0.3rem 0.7rem;
 }
 
 .home-series-callout-label {
+  grid-row: 1 / span 2;
   font-size: 0.68rem;
   font-weight: 500;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--brand);
+}
+
+.home-series-callout-entry {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.2rem 0.45rem;
+  min-width: 0;
 }
 
 .home-series-callout-title {
@@ -1448,6 +1457,16 @@ html {
 .home-series-callout a:hover {
   text-decoration: underline;
   text-underline-offset: 3px;
+}
+
+@media (max-width: 520px) {
+  .home-series-callout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .home-series-callout-label {
+    grid-row: auto;
+  }
 }
 
 /*****************************************************************************/

--- a/index.html
+++ b/index.html
@@ -11,12 +11,19 @@ description: "Christopher Meiklejohn — Ph.D., Software Engineering (CMU). Note
     Recent posts. Topic pages: <a href="/zabriskie/">Zabriskie</a> · <a href="/agents/">AI Agents</a> · <a href="/distributed-systems/">Distributed Systems</a>. Or the full <a href="/archive.html">archive</a>.
   </p>
 
-  <p class="home-series-callout">
+  <div class="home-series-callout" aria-label="Blog series">
     <span class="home-series-callout-label">Series</span>
-    <a class="home-series-callout-title" href="/series/the-machine-in-the-lab/">The Machine in the Lab</a>
-    <span class="home-series-callout-sep" aria-hidden="true">·</span>
-    <a class="home-series-callout-overview" href="/series/the-machine-in-the-lab/">7-part series →</a>
-  </p>
+    <span class="home-series-callout-entry">
+      <a class="home-series-callout-title" href="/series/the-machine-in-the-lab/">The Machine in the Lab</a>
+      <span class="home-series-callout-sep" aria-hidden="true">·</span>
+      <a class="home-series-callout-overview" href="/series/the-machine-in-the-lab/">7-part series →</a>
+    </span>
+    <span class="home-series-callout-entry">
+      <a class="home-series-callout-title" href="/series/multi-agent-systems/">Getting Up to Speed on Multi-Agent Systems</a>
+      <span class="home-series-callout-sep" aria-hidden="true">·</span>
+      <a class="home-series-callout-overview" href="/series/multi-agent-systems/">8-part overview →</a>
+    </span>
+  </div>
 
   <section class="archive-section home-recent-section" aria-labelledby="home-recent-heading">
     <h2 id="home-recent-heading" class="home-section-title archive-section-heading">Recent</h2>


### PR DESCRIPTION
## Summary
- restore the MAS series link alongside The Machine in the Lab
- present both series as deliberate rows in the homepage callout

## Verification
- production Jekyll build
- visually checked the two-row callout in the local preview