### PR TITLE
Clarify Machine in the Lab series overview

### DIFF
--- a/css/mas-series.css
+++ b/css/mas-series.css
@@ -575,6 +575,21 @@ a.series-landing-link:hover .series-landing-title {
   flex: 1;
 }
 
+.series-landing-copy {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.series-landing-subtitle {
+  font-family: var(--font-ui);
+  font-size: 0.82rem;
+  line-height: 1.35;
+  color: var(--fg-muted);
+}
+
 .series-landing-date {
   font-family: var(--font-mono);
   font-size: 0.78rem;

--- a/series/the-machine-in-the-lab.md
+++ b/series/the-machine-in-the-lab.md
@@ -1,27 +1,31 @@
 ---
 layout: page
 title: "The Machine in the Lab"
-description: "A PhD researcher's field report on using LLM agents for an ambitious audio project, losing two notebooks, returning to a live song guesser for fans, and following it through a Goose tour."
+description: "How I used an autonomous LLM research program to build a live Goose song guesser, discarded two invalid notebooks, and began testing it during a real tour."
 permalink: /series/the-machine-in-the-lab/
 series: lab
 ---
 
-<p class="series-landing-lead">By my estimate, in this project an LLM agent compressed weeks of implementation into hours. It also helped compress weeks of invalid research into hours, then handed it back as clean code, persuasive charts, and a conclusion that looked finished.</p>
+<p class="series-landing-lead">I wanted to build a tool that could tell Goose fans what song they were hearing while a show was still happening. I also wanted an autonomous LLM system to do the research needed to build it. The system would propose experiments, write and run code, evaluate the results, and decide what to try next. The tool became SetScope.</p>
 
 <p class="series-landing-meta">
-  This is a field report from an audio-research project that lost two notebooks to data leakage and an inherited segmentation default, built an elaborate review system, watched that system miss a different class of error, and eventually developed a workflow that could preserve failures instead of explaining them away.
+  By my estimate, the agent compressed weeks of implementation into hours. It also helped produce two polished research notebooks that I later discarded. One leaked recordings between training and test. The other analyzed the wrong portions of the songs because it inherited a 90-second segmentation rule that contradicted the method I had written. Both came with clean code, persuasive charts, and conclusions that sounded finished.
 </p>
 
 <p class="series-landing-meta">
-  I came to the project with a PhD and years of systems-research experience. I was trying to find out whether an LLM agent could make a serious independent research program possible at a scale I could not manage alone. The project started as automatic set detection, detoured into questions about improvisation that were much harder to answer cleanly than they appeared, and eventually returned to its original target: a tool that listens to a live Goose show and tells viewers which song is probably playing. On August 13, SetScope emitted correct song identities while the show was happening, using audio that had not existed when the system was built. Those guesses were the output of a fan-facing product, not scientific findings. The saved record later found correct identities emitted at least once for 10 of 12 song performances. A post-show diagnostic also found two misses and three false switches, but capture and scoring problems prevent those observations from becoming a whole-show accuracy, stability, or viewer-benefit estimate.
+  I have a PhD and years of systems-research experience. That background did not prevent me from accepting either result. The project began with automatic song and set detection. The recordings pulled it into harder questions about improvisation. After both notebooks failed, I returned to the original goal: build the live song guesser.
 </p>
 
 <p class="series-landing-meta">
-  The final post will return after the eleven-show August 13-28 western run with the longer product record: which versions ran, how quickly correct guesses appeared, where the system switched or stayed wrong, when capture failed, and what the screen and publication paths actually produced. That retrospective will report the defined August run rather than the complete summer tour, and it will not compress evolving software into one flattering score. Any claim that it made shows easier to follow will remain first-person or qualitative unless we collect direct viewer evidence.
+  On August 13, we ran SetScope during a Goose show whose audio had not existed during development. The saved record shows that SetScope produced the right song at least once for 10 of the 12 performances. It also missed two performances and switched songs three times when it should not have. The record is incomplete, so those numbers do not amount to a whole-show accuracy score.
 </p>
 
 <p class="series-landing-meta">
-  <strong>Who this is for:</strong> people using LLMs to design experiments, write analysis code, operate research infrastructure, or interpret results. This is not a prompting guide. It is about information boundaries, measurement validity, execution validity, hidden state, and which decisions require durable permissions and evidence outside the agent's own artifact chain.
+  This series will follow that story from beginning to end. It starts with what the autonomous researcher made possible and how it convinced me twice that invalid work was finished. It then explains how a review system in which every check passed still accepted the wrong interpretation of the audio. After the eleven-show August 13-28 run, the final post will report which versions actually ran, how quickly correct guesses appeared, where the system failed, and what the surviving records can establish about the viewer-facing system.
+</p>
+
+<p class="series-landing-meta">
+  This is not a prompting guide. It is for people using LLMs to run experiments or build the systems around them. The question throughout is simple: when an agent can produce the next result by itself, what evidence gets to say that the result is wrong?
 </p>
 
 {% if jekyll.environment == "development" %}
@@ -34,6 +38,7 @@ series: lab
   {%- assign published_urls = site.posts | where: "series", "lab" | map: "url" -%}
   <ol>
     {%- for entry in site.data.lab_series -%}
+      {%- capture part_prefix -%}Part {{ forloop.index }}. {% endcapture -%}
       {%- assign is_published = false -%}
       {%- for u in published_urls -%}
         {%- if u == entry.url -%}{%- assign is_published = true -%}{%- break -%}{%- endif -%}
@@ -41,12 +46,18 @@ series: lab
       <li class="series-landing-item{% unless is_published %} series-landing-pending{% endunless %}">
         {%- if is_published -%}
           <a href="{{ entry.url }}" class="series-landing-link">
-            <span class="series-landing-title">{{ entry.title }}</span>
+            <span class="series-landing-copy">
+              <span class="series-landing-title">{{ entry.title | remove_first: part_prefix }}</span>
+              <span class="series-landing-subtitle">{{ entry.subtitle }}</span>
+            </span>
             {%- if entry.date -%}<span class="series-landing-date">{{ entry.date | date: "%B %-d, %Y" }}</span>{%- endif -%}
           </a>
         {%- else -%}
           <span class="series-landing-link series-landing-link-pending">
-            <span class="series-landing-title">{{ entry.title }}</span>
+            <span class="series-landing-copy">
+              <span class="series-landing-title">{{ entry.title | remove_first: part_prefix }}</span>
+              <span class="series-landing-subtitle">{{ entry.subtitle }}</span>
+            </span>
             <span class="series-landing-date">{% if entry.status == "source-draft" %}source draft{% elsif entry.status == "draft" %}draft in progress{% elsif entry.status == "collecting-results" %}collecting tour results{% elsif entry.status == "blocked-on-result" %}blocked on evidence{% else %}planned{% endif %}</span>
           </span>
         {%- endif -%}


### PR DESCRIPTION
## Summary
- explain SetScope and the autonomous research loop in plain English
- present the project chronology and August 13 result with bounded claims
- add independent takeaways to the seven-post series list

## Verification
- `bundle exec jekyll build`
- three hostile editorial passes; final gate found no substantive blockers
- local browser review at desktop viewport