### PR TITLE
Schedule Machine in the Lab Parts 2 through 6

### DIFF
--- a/_data/lab_series.yml
+++ b/_data/lab_series.yml
@@ -66,7 +66,8 @@
   title: "Part 2. Two Notebooks Lost"
   subtitle: "The code was mostly right. The experiments were already lost."
   url: /series/the-machine-in-the-lab/two-notebooks-lost-series/
-  status: draft
+  status: scheduled
+  date: 2026-08-18
   estimated_words: "3,000-3,500 words"
   purpose: "Show what happened when an experienced, PhD-trained systems researcher used an LLM agent to make an ambitious self-directed audio-research program tractable: two silent setup decisions became foundations for plausible downstream work while creating different information and meaning failures."
   discovery_loop_role: "Show the uncontrolled loop in practice: an agent could propose, implement, run, interpret, and extend experiments faster than the researcher could inspect the premises entering the next iteration."
@@ -103,7 +104,8 @@
   title: "Part 3. The Holdout Is a One-Way Door"
   subtitle: "Evidence cannot independently confirm the claim it helped shape."
   url: /series/the-machine-in-the-lab/the-holdout-is-a-one-way-door/
-  status: draft
+  status: scheduled
+  date: 2026-08-21
   estimated_words: "2,500-3,000 words"
   purpose: "Explain leakage as an information-flow problem rather than a faulty train_test_split call, using the project history to show how files, performances, caches, labels, derived features, and human adaptation can all cross the boundary."
   discovery_loop_role: "Define the loop's memory problem: results from one iteration change the agent, artifacts, and human operator, so evidence cannot remain independent merely by living in another directory."
@@ -140,7 +142,8 @@
   title: "Part 4. When Every Check Passes"
   subtitle: "All the artifacts agreed. The interpretation had never been tested."
   url: /series/the-machine-in-the-lab/when-every-check-passes/
-  status: draft
+  status: scheduled
+  date: 2026-08-24
   estimated_words: "2,800-3,400 words"
   purpose: "Pay off the meaning problem first exposed by Notebook 2 and demonstrate the limit of process-heavy agent review: a result can pass every internal-consistency gate and still make the wrong claim about the underlying world."
   discovery_loop_role: "Define the loop's evaluator problem: rapid iteration optimizes whatever signal closes the loop, including a technically consistent proxy that does not measure the claimed phenomenon."
@@ -179,7 +182,8 @@
   title: "Part 5. The Browser Is Part of the Experiment"
   subtitle: "A model score cannot tell you what the live system actually heard."
   url: /series/the-machine-in-the-lab/the-browser-is-part-of-the-experiment/
-  status: draft
+  status: scheduled
+  date: 2026-08-27
   estimated_words: "3,000-3,800 words"
   purpose: "Show why component metrics cannot predict the behavior of an end-to-end product path, and why hands-on browser rehearsals were part of building and evaluating the product rather than a ceremonial demo after the research. SetScope has an ordinary product job: show a viewer the song Goose is probably playing right now. Its guesses are product outputs, not scientific findings."
   discovery_loop_role: "Define the loop's execution problem: an experiment performed against an archive, component, or synthetic input does not evaluate the browser, audio transport, controller, and display path the product actually runs."
@@ -222,7 +226,8 @@
   title: "Part 6. A Discovery Loop That Can Say No"
   subtitle: "Bound the agent, preserve the failures, and let the evidence limit the claim."
   url: /series/the-machine-in-the-lab/what-we-built-instead/
-  status: draft
+  status: scheduled
+  date: 2026-08-30
   estimated_words: "3,200-4,000 words"
   purpose: "Synthesize the practical research system that emerged and close the story with the fan-facing product it helped build. SetScope's guesses are not offered as scientific evidence: they are the output of a live song guesser. The methodological claim concerns how the project records failures and limits what may be inferred from engineering tests; broad numerical reliability claims remain reserved for clean evaluations if the author later chooses to make them."
   discovery_loop_role: "Present the systems contribution directly: a loop needs typed state, provenance, claim-scoped permissions, independent checks, invalid outcomes, stop conditions, and a promotion boundary that the generating agent cannot silently cross."

--- a/_drafts/a-discovery-loop-that-can-say-no-three-pass-audit.md
+++ b/_drafts/a-discovery-loop-that-can-say-no-three-pass-audit.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "A Discovery Loop That Can Say No: Three-Pass Editorial Audit"
+date: 2026-08-16 03:04:00 -0400
+published: false
+---
+
+# Audit Scope
+
+This record covers `_posts/2026-08-30-a-discovery-loop-that-can-say-no.markdown`. The structural, evidence, and rendered-readability reviews were run independently and in that order. Evidence and readability were rerun after later edits.
+
+# Pass 1: Structural Reader
+
+The article now states plainly that an autonomous research program was used to improve SetScope and connects that project to automated discovery-loop work without speculating about another system's implementation. The three prior failures are stated as separate boundaries. Outcome-informed limitations precede the engineering result, and the final section leads to the longitudinal August record.
+
+**Result:** Pass after revision.
+
+# Pass 2: Evidence Reviewer
+
+The Dispatch 002 conclusion is described as generally unsupported rather than wholly wrong. The 263-entry halt, 113 eligible shows, 75/38 split, 65 correct initial locks, ten abstentions, 100 percent selective precision, 86.67 percent coverage, sixty-second median, 65,085 observations, 61,446 scoreable observations, 92.89 percent correct state, and 632/733 transition result are supported. Three untraceable unscoreable subcategories were removed. The opened, outcome-informed, publication-disabled boundary remains explicit.
+
+**Result:** Pass after correction and recheck.
+
+# Pass 3: Readability Editor
+
+Raw result-field names and the full product hierarchy made the middle read like a protocol artifact. They were translated into direct prose, version 0532 was introduced as the selected controller candidate, and the hierarchy became several shorter sentences. The remaining two-column accounting table fits a 375 px viewport.
+
+**Result:** Pass.

--- a/_drafts/the-browser-is-part-of-the-experiment-three-pass-audit.md
+++ b/_drafts/the-browser-is-part-of-the-experiment-three-pass-audit.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "The Browser Is Part of the Experiment: Three-Pass Editorial Audit"
+date: 2026-08-16 03:03:00 -0400
+published: false
+---
+
+# Audit Scope
+
+This record covers `_posts/2026-08-27-the-browser-is-part-of-the-experiment.markdown`. The structural, evidence, and rendered-readability reviews were run independently and in that order. Evidence and readability were rerun after later edits.
+
+# Pass 1: Structural Reader
+
+The opening now distinguishes the alarming Animal observation from the later six-minute capture that supplied causal evidence. Transport repair and gate-policy diagnosis have separate sections. The extended August 13 product history was compressed so Part 5 owns deployed-path validity and Part 7 owns the tour record. The final question leads directly to the autonomous control system in Part 6.
+
+**Result:** Pass after revision.
+
+# Pass 2: Evidence Reviewer
+
+The historical 46-of-54 result is correctly described as leakage-disjoint for its exact rows but narrow: 45 of 254 catalog labels and component-track input. Transport gaps, gate outputs, short decoded segments, CoreAudio repair, the 0.5-second tolerance, Animal replay, forty-second policy gain, two-song transition, and 48/47 shutdown defect are supported. The Animal premusic lock is labeled as a screenshot observation. The August 13 trace and later dateless/setlist-free ledger fields are attributed separately.
+
+**Result:** Pass after correction and recheck.
+
+# Pass 3: Readability Editor
+
+The live-show section previously placed a long qualification before its result and then stated the result twice. It now opens on the live capability, asks the narrow question, and follows with one evidence paragraph and one limitations paragraph. The final rendered reread found no remaining flow or mobile-layout defect.
+
+**Result:** Pass.

--- a/_drafts/the-holdout-is-a-one-way-door-three-pass-audit.md
+++ b/_drafts/the-holdout-is-a-one-way-door-three-pass-audit.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "The Holdout Is a One-Way Door: Three-Pass Editorial Audit"
+date: 2026-08-16 03:01:00 -0400
+published: false
+---
+
+# Audit Scope
+
+This record covers `_posts/2026-08-21-the-holdout-is-a-one-way-door.markdown`. The structural, evidence, and rendered-readability reviews were run independently and in that order. Evidence and readability were rerun after later edits.
+
+# Pass 1: Structural Reader
+
+The article now explains that derived artifacts inherit source roles before introducing the purge. It moves from the historical split, to caches, to human adaptation, to the claim-scoped one-way door, and finally to the limit of clean independence. HARKing is expanded on first use. The handoff to measurement validity remains distinct from leakage.
+
+**Result:** Pass after revision.
+
+# Pass 2: Evidence Reviewer
+
+The opening was corrected to the documented pair-row mechanism. The 1,120-file purge now uses the audited categories: 51 jam-only chroma arrays, 153 jam-feature variants, 320 sliding-window variants, 325 per-track summaries, and 271 other feature files. The mixed Notebook 1 and Notebook 2 lineage remains explicit. Current grouping, opaque-label, frozen-plan, and one-time-opening controls are bounded to their stated protocols.
+
+**Result:** Pass after correction and recheck.
+
+# Pass 3: Readability Editor
+
+The mixed-lineage paragraph carried the audit scope, both failure types, and the joint-removal rationale in one block. It was split after the audit limitation. A final rendered read found no remaining flow problem or mobile overflow.
+
+**Result:** Pass.

--- a/_drafts/the-machine-in-the-lab-series-architecture.md
+++ b/_drafts/the-machine-in-the-lab-series-architecture.md
@@ -1,0 +1,1159 @@
+---
+layout: page
+title: "The Machine in the Lab: Series Architecture"
+description: "The complete argument map, post contracts, transitions, and adversarial review protocol for The Machine in the Lab."
+permalink: /series/the-machine-in-the-lab/series-architecture/
+---
+
+This is not a prose outline. It is the logical architecture of the series. Its purpose is to make the progression inspectable before the articles acquire narrative momentum, polished transitions, or conclusions that feel inevitable because they have been written well.
+
+An adversarial reviewer should be able to use this document to answer five questions:
+
+1. Does every post earn a distinct claim?
+2. Does each claim follow from the evidence and the claims before it?
+3. Can every post be understood and valued by a reader who has not read the others?
+4. Does the complete series answer the question it opens without pretending the final evidence is stronger than it is?
+5. Could any post be removed or merged without breaking the argument?
+
+The ordinary [editorial plan](/series/the-machine-in-the-lab/editorial-plan/) remains the source for proposed sections, evidence inventories, lengths, and exclusions. This document governs the argument across those posts.
+
+## 1. The Series Contract
+
+### Controlling question
+
+What has to change when an LLM agent can implement empirical research faster than its supervising researcher can inspect the methodological decisions embedded in that implementation?
+
+### Series answer
+
+The answer is not simply more careful prompting, more agent reviewers, more reproducible code, or a larger holdout. This case exposed three distinct boundaries that an LLM-mediated empirical workflow must represent. They are not offered as a complete taxonomy of scientific validity:
+
+1. **The information boundary:** what data, outcomes, labels, and derived artifacts may influence design or fitting.
+2. **The meaning boundary:** whether the operational measurement corresponds to the phenomenon named in the claim.
+3. **The execution boundary:** whether the complete deployed path actually receives and processes the phenomenon the evaluation assumes it receives.
+
+Those boundaries must be represented in durable state outside the model, enforced before downstream work multiplies, and evaluated with evidence appropriate to the claim. A better process does not guarantee a successful result, prevent every invalid promotion, or make human approvals non-ceremonial. It can create an inspectable record, restrict what an agent is permitted to do automatically, and make a stronger claim require an explicit, auditable violation of the stated evidence policy.
+
+### Author and project frame
+
+The author came to this project with a PhD and years of experience doing systems research. That background is context, not evidence that any result is correct. The series therefore cannot explain the failures away as the predictable result of an inexperienced person asking an LLM to perform a technical task they did not understand.
+
+The actual experiment was more interesting: could an experienced researcher use an LLM agent to make a self-directed audio-research program possible at a scale that would otherwise require a team or much more time? The project originally began as an automatic set-detection project: could Zabriskie listen to an in-progress Goose show and identify the song without consulting an external setlist? The available live-audio corpus and the apparent power of audio features then pulled the work into a more ambitious research detour about how jam-band listeners describe improvisation, structure, and transitions. Those questions were interesting, but they contained disputed constructs, subjective boundaries, inherited labels, and many plausible operational definitions. They were much harder to answer cleanly than they first appeared.
+
+The research program eventually returned to its original song-recognition target with a directly observable product question: can a dateless, setlist-free system listen to a continuous live Goose stream and emit a correct current-song identity within a stated time window?
+
+SetScope has a deliberately ordinary product purpose: show a viewer its best current-song guess so the viewer does not have to consult an external setlist. The displayed song title is a product output, not a scientific finding. A live browser run is a product field test, not a study of Goose's music. Its logs can document what one version did under recorded conditions, and clean corpus evaluations can support bounded reliability claims, but neither turns the guesser itself into a scientific instrument. The research object in this series is the human-agent development and evaluation process: which conclusions that process may draw from a component score, a field test, a sealed evaluation, or a deployment record.
+
+The August 13, 2026 San Diego show supplied a genuine live field test: the audio did not exist during training or development, and SetScope produced blind song guesses while the show was happening without receiving the date or setlist. The preserved runtime record emitted correct identities at least once for 10 of the 12 song performances. A later internal acoustic-family diagnosis found 11 of 12, but that is not an additional product output. These are descriptive facts about live runtime behavior, not a scientific result or a formal whole-show accuracy estimate. Set 1 failed the planned capture-integrity check, and the 61.5 percent Set 2 held-state calculation used an approximate truth timeline reconstructed after the show rather than the required frozen boundary artifact. No preserved UI-observation or outward-publication receipt was located, so the evidence reaches the controller but not confirmed user-visible delivery. The field test establishes the practical fact that the runtime can emit correct identities on never-before-existing live audio; it does not establish a formal accuracy rate or reliable continuous operation. The remaining product questions concern false transitions inside jams, abstention and unknown material, continuous held-state accuracy, latency, capture integrity, display and publication delivery, catalog coverage, and independent generalization.
+
+That return is the constructive arc of the series. The project did not solve the broad improvisation questions it encountered during the detour. It returned to its original product ambition with a target whose inputs, outputs, errors, and remaining uncertainty could be inspected. SetScope is therefore neither a convenient late success nor a tighter operationalization of improvisation. It is the original fan-facing problem, re-entered after the failed detour changed how the project would evaluate its own work.
+
+### The causal mechanism
+
+The series is not built on the claim that LLMs invented research error. Humans leak data, choose bad proxies, overinterpret exploratory findings, and test the wrong system without any machine assistance.
+
+The narrower mechanism is:
+
+1. An agent makes implementation dramatically cheaper and faster.
+2. Empirical validity depends on setup choices that ordinary software review can treat as minor implementation details.
+3. The agent is rewarded for plausible forward progress, so reasonable defaults and inherited assumptions often remain implicit.
+4. Plausible code quickly produces tables, charts, reports, and prose.
+5. Every downstream artifact increases the financial, social, and psychological cost of reopening the original decision.
+6. Internal checks tend to compare artifacts within the same chain, allowing every check to agree with the same mistaken premise.
+7. The speedup is therefore real, but it applies equally to valid work and invalid work.
+
+The series must demonstrate this mechanism rather than treating "AI makes mistakes" as its thesis.
+
+### Reader promise
+
+The reader should leave with:
+
+- a precise explanation of why plausible implementation is not enough for empirical work;
+- three separate validity boundaries they can apply to their own projects;
+- a concrete account of how those boundaries failed in one research program;
+- an account of how an automatic set-detection project detoured into broad improvisation research and returned to its original target as a directly testable live-system question;
+- a reusable protocol for assigning data roles, freezing decisions, preserving provenance, checking the underlying phenomenon, and validating deployed paths; and
+- an honest conclusion whose wording follows the evidence coordinates, including abstentions and failures, rather than a success story chosen in advance.
+
+### Scope
+
+The series concerns computational empirical research in which an LLM agent helps design experiments, write analysis code, operate infrastructure, interpret results, or draft claims. The audio project is the running case because its inputs can be inspected directly and because it crossed from exploratory analysis into a live product.
+
+The series does not attempt to define all science, evaluate every form of AI-assisted scholarship, prove that agent-mediated work is generally less reliable, or claim that the proposed operating protocol is sufficient for every field.
+
+## 2. The Complete Progression
+
+The series has a six-post methodological arc and a seventh-post product payoff:
+
+| Part | Reader's question | New claim earned | Remaining problem |
+| --- | --- | --- | --- |
+| 1. Science at LLM Speed | Why is this a research problem now? | LLMs make complete-looking research artifacts cheap; a valid claim still requires evidence outside the generated artifact chain. | What does the failure look like inside an actual project? |
+| 2. Two Notebooks Lost | How can plausible work become invalid? | In empirical work, setup decisions are part of the experiment. One silent choice can invalidate every correct artifact downstream. | Which distinct information and meaning boundaries did the two failures expose? |
+| 3. The Holdout Is a One-Way Door | What counts as leakage and independence? | Independence belongs to the complete information history of the research process, including derived artifacts and human adaptation. | Can a clean, preregistered, internally consistent experiment still make the wrong claim? |
+| 4. When Every Check Passes | What can process and provenance fail to detect? | Internal consistency cannot establish construct or measurement validity. The named interpretation must be checked against the underlying phenomenon through a different evidence path. | What new validity problem appears when the project leaves the jam-research detour, returns to automatic song identification, and evaluates a live deployed system? |
+| 5. The Browser Is Part of the Experiment | Why can an offline metric fail in use? | Product behavior belongs to the complete deployed path. The August 13 field test produced correct blind controller outputs on never-before-existing audio while exposing capture, transition, held-state, unknown-song, and missing display/publication receipts that offline metrics did not measure. | What operating system can represent and coordinate all three case-derived boundaries without stopping useful work? |
+| 6. A Discovery Loop That Can Say No | What does a defensible agent-mediated workflow look like? | Bounded experiments, durable data roles, immutable artifacts, independent reality checks, complete-product rehearsals, and claim-specific evidence can make the process auditable. The deployed prototype and any broad numerical reliability or viewer-benefit claim are separate outcomes. | What happens when that operating discipline meets an eleven-show August run of changing versions, imperfect transport, real songs, and publication paths? |
+| 7. What Happened on the August Run | What did the product actually emit from August 13-28? | A live product must be reported as a versioned operational history: recognition, latency, stability, availability, and publication behavior cannot be collapsed into one model score. | Future product work continues, but the series has reported the defined August-run record without inventing a complete-tour or viewer-effect study. |
+
+### The case-derived three-boundary spine
+
+Parts 3 through 5 must not collapse into a generic sequence of mistakes. These are the three boundary failures this project exposed, not an exhaustive theory. Sampling, statistical inference, uncertainty, population validity, incentives, and other scientific failure classes remain outside this spine unless a post addresses them explicitly.
+
+| Boundary | Governing question | Characteristic failure | Evidence that can answer it | Primary post |
+| --- | --- | --- | --- | --- |
+| Information | Did outcomes or related information influence design, fitting, or selection? | Performance leakage, contaminated caches, opened holdouts, adaptive thresholds, human HARKing | Provenance, grouping, point-in-time reconstruction, opaque labels, frozen roles and hashes | Part 3 |
+| Meaning | Does the operational measurement correspond to the construct named in the claim? | A detector agrees with labels for the wrong acoustic event; one person's labels are treated as a shared construct; a proxy receives a stronger name than it earned | Independent domain inspection, blinded annotation, agreement studies, alternative operationalizations, construct validation | Part 4 |
+| Execution | Did the evaluated system receive and process valid input through the same path used in deployment? | Archive metrics look good while browser capture drops samples; a component vote is overridden incorrectly; premusic becomes a song lock | Source-frame accounting, exact-byte replay, complete-product telemetry, whole-show scoring, prospective shadow use | Part 5 |
+
+Part 6 is not a fourth boundary. It is the operating protocol that coordinates all three and keeps one evidence dimension from substituting for another.
+
+### The discovery-loop reading
+
+The series is also a field report about automated experimental loops. This connection should be visible to readers following the new generation of systems that propose, execute, evaluate, and revise experiments, including the contemporary company Discovery Loop, without turning the series into commentary about a company whose implementation is not public.
+
+1. Part 1 establishes why automating the loop has become a live research and systems objective.
+2. Part 2 shows an uncontrolled loop producing plausible experimental state faster than its premises could be inspected.
+3. Part 3 identifies the information problem: iteration changes what the agent and operator know, so independence must be represented as lineage rather than file placement.
+4. Part 4 identifies the evaluator problem: the loop can optimize a reproducible proxy that does not measure the named phenomenon.
+5. Part 5 identifies the execution problem: the loop must exercise the actual input, transport, controller, and display path rather than only its strongest component.
+6. Part 6 supplies the control plane: typed state, evidence roles, invalid outcomes, stop conditions, and promotion permissions outside the generating agent.
+7. Part 7 reports the loop as history, preserving which version produced each success and failure rather than attributing all outcomes to the final system.
+
+The recruiting signal should come from the technical fit. Parts 1 and 6 may name Discovery Loop. The other posts should establish the mechanics without repeatedly invoking Jeff Dean or speculating about the company's architecture.
+
+## 3. The Claim Ladder
+
+Each rung depends on the one before it. A draft that jumps past a rung has broken the series even if every sentence in the draft is individually true.
+
+### S1. Cheap research-like production changes what must be inspected
+
+LLMs participate in literature search, writing, review, code, analysis, and hypothesis generation. They can contribute to verifiable work, and they make complete-looking scholarly artifacts cheap to produce. That observation does not establish a general rate comparison between production and verification costs. It creates the narrower question that controls the series: what evidence outside the generated artifact chain judges each output?
+
+### S2. Plausible implementation can conceal different kinds of methodological choice
+
+The two lost notebooks show the local mechanism, but they do not fail in the same way. Correct-looking code created a data split without protecting independence and inherited a segmentation constant without establishing that the resulting unit represented the phenomenon in the claim. The downstream artifacts were internally plausible because most of the implementation was correct. Notebook 1 creates the information-validity debt paid in Part 3; Notebook 2 creates the meaning-validity debt paid in Part 4.
+
+### S3. Independence is historical, not spatial
+
+A clean directory or a `train_test_split` call does not establish independence. Performances, shows, caches, labels, feature choices, thresholds, and human knowledge all carry information. Once an outcome changes design, the affected data may support engineering but cannot return to sealed confirmation status.
+
+### S4. Independence does not establish meaning
+
+Notebook 2 first exposed the danger of letting a convenient segmentation procedure define the phenomenon being studied. Even a later, cleanly executed plan can test correspondence to a label while being interpreted as correspondence to the world. The Dispatch 002 chain pays off that deferred problem because it passed the process built after the notebook failures and still reached the wrong acoustic interpretation.
+
+### S5. A valid measurement does not establish deployed behavior
+
+Offline audio decoded directly from archives does not exercise browser playback, system routing, capture, segmentation, gates, state transitions, or publication logic. The live path can therefore fail before or after the model while the model's offline result remains unchanged.
+
+### S6. Auditability comes from constrained claims, not procedural confidence
+
+The final protocol assigns each artifact a role and each claim a required position on the evidence axes. It can show that a process is more auditable and that some specific failure shapes are now caught earlier. The August 13 field test documents correct blind guesses on genuinely future live audio, but its capture and truth-timeline failures prevent it from supplying a whole-show performance estimate. The existence of the prototype, correct emitted guesses, broad quantitative reliability, viewer benefit, and authorization for automatic public posting remain separate claims and decisions.
+
+### S7. An August run is a product history, not one score
+
+The final retrospective applies the distinctions rather than adding a fourth validity boundary. SetScope may change during the eleven-show August 13-28 western run, runs may fail before inference, songs may segue without clean boundaries, and external setlist timestamps may describe a different event from a SetScope lock. The honest product record therefore preserves versions, clocks, invalid operations, abstentions, and separately verified display or publication behavior before aggregating. Its conclusion describes how this evolving tool operated during that defined window, not across the 13 earlier summer shows carrying the same source tour label. First-person feedback may describe whether it felt helpful, but the telemetry alone does not estimate a viewer effect.
+
+## 4. Post Contracts
+
+Every post has two contracts. The **standalone contract** states what a reader receives without reading the series. The **series contract** states what logical work the post performs in the larger arc.
+
+## Part 1. Science at LLM Speed
+
+### Working title proposition
+
+**Title:** Science at LLM Speed
+**Subtitle:** Research-like output is cheap. Valid claims still need an outside judge.
+
+The exact words can change. The title and subtitle must distinguish cheap production from independently judged evidence without asserting an unsupported comparison between the rates or costs of production and verification.
+
+### Standalone contract
+
+A reader unfamiliar with the audio project should understand the current range of LLM involvement in research, see both documented failure and credible acceleration, and leave with a test for distinguishing generated scholarly form from externally judged work.
+
+### Series function
+
+Part 1 establishes why the personal story is not only a software postmortem. It defines the general pressure that the rest of the series examines in one tractable case.
+
+### Question answered
+
+What is different about doing research when the same class of system can search the literature, draft the paper, write the analysis, review the result, and explain why the result is convincing?
+
+### Argument chain
+
+1. Nonexistent citations in real submissions demonstrate that fluent scholarly form can enter institutional processes without the scholarship behind it.
+2. Large-scale studies suggest LLM assistance is affecting manuscript production and review, although attribution and causality must be qualified.
+3. Explicitly assisted review and retrieval-grounded literature systems show that model involvement is not itself the problem.
+4. Verifiable systems such as program search and experimentally evaluated hypothesis systems show that LLMs can participate in real discovery when something outside generated prose judges the output.
+5. A qualitative CHIWORK study of end-user data analysis shows the relevant capability and friction directly: participants could use generative assistance for information gathering, hypothesis generation, and analysis strategy while struggling to specify context and verify results. Its sample does not establish population prevalence.
+6. A 2026 bioinformatics perspective supplies the conceptual warning without pretending it is an experiment: access to functional analysis code does not supply the expertise required to judge the reference data, method, parameters, or scientific interpretation.
+7. Science-shaped fan analytics predates LLMs; the adjacent project does not establish a new historical category or a causal increase. It is useful precisely because it is transparent, serious, and published as a fan data product rather than an academic paper. It makes the extra-academic publication category concrete without establishing anything about the creator's institutional affiliation, formal training, or use of an LLM.
+8. Part 1 should not put that project's labels or particular musical claim on trial. Doing so would both identify an anonymized example and spend Part 4's central lesson before the author's own evidence earns it. The detailed methodological audit remains private source work, not the argument of this section.
+9. Any claim about the project's public reception must be omitted unless separately documented; reception is not required for the series' logic.
+10. Our project is not observing this shift from above. It produced the same scientific-looking completeness and later supplies the series' substantive evidence about what those forms can conceal.
+11. Part 1 therefore raises the category problem beyond journals and conferences; Parts 2 through 5 show, through the author's own project, what independent adjudication actually requires.
+
+### Claim earned
+
+LLM assistance can make sophisticated analytical activity and research-like artifacts easier to produce, but polished form, reproducible calculation, and internal agreement are not substitutes for independently adjudicated evidence.
+
+### Evidence base and status
+
+Primary research papers, institutional policies and reports, end-user data-analysis research, a domain-expert perspective with its evidentiary status labeled, and public project methodology and analytical claims.
+
+### Required counterarguments
+
+- Humans fabricate citations and overclaim results too.
+- A fan data product is allowed to be exploratory, subjective, and entertaining.
+- Reproducibility and transparency remain valuable even when they do not establish validity.
+- Some LLM-mediated systems produce externally verifiable contributions.
+- An outside judge can still be correlated with the generator, selected to reward the candidate, or itself model-generated; externality is necessary for some claims but never sufficient by itself.
+
+The answer is not that these objections are wrong. The series claims rapid propagation in this case and category confusion, not uniquely machine-created misconduct. The adjacent project illustrates that a serious science-shaped data product can be published outside a formal academic venue; it does not establish an LLM cause, creator affiliation, widespread reception, or Part 1's construct-validity argument.
+
+### Standalone context requirement
+
+Part 1 should need no prior series context. Its closing introduction to the audio lab must be short enough that the article remains a field-level argument rather than the first chapter of a memoir.
+
+### Handoff to Part 2
+
+If generated work must be judged outside its own artifact chain, what happens when a real project mistakes plausible implementation and clean outputs for those outside checks?
+
+### Red-team failure conditions
+
+- The post becomes a catalogue of alarming AI anecdotes.
+- The unnamed fan project becomes an identifiable antagonist rather than a bounded example of science-shaped work outside formal academic publication.
+- The post litigates label reliability, construct validity, or the named musical result and thereby performs Part 4 in miniature.
+- The absence of peer review is treated as proof that the adjacent analysis is false.
+- Positive acceleration cases receive less methodological scrutiny than negative cases.
+- The post ends with "humans must verify AI" without defining what independent verification means.
+
+### Removal test
+
+Without Part 1, the series becomes a personal tool-failure story and loses the reason these incidents matter beyond one repository. It also loses the positive cases needed to explain why people accept the risk.
+
+## Part 2. Two Notebooks Lost
+
+### Working title proposition
+
+**Title:** Two Notebooks Lost
+**Subtitle:** In empirical work, setup is the experiment.
+
+### Standalone contract
+
+A reader should understand how two small, plausible implementation choices invalidated a large body of work, why ordinary code review did not surface them, and why the author shares responsibility for accepting the outputs.
+
+The author should be introduced as an experienced, PhD-trained systems researcher attempting an ambitious self-directed research program with LLM assistance. The credential is not an appeal to authority. It establishes that conventional research training did not automatically solve the supervision problem created by the agent's speed.
+
+The existing *Two Notebooks Lost* file remains contemporaneous source material rather than a contract-compliant series draft. Its phrase "the question I started with" refers to the first jam-research notebook question, not the origin of the full Zabriskie audio project. Part 2 will be a separate series draft built from that source. It needs the full set-detection-to-jam-detour chronology and a selective compression of the later governance coda assigned to Parts 4 and 6. This architecture does not authorize changing the contemporaneous source file itself without author approval.
+
+### Series function
+
+Part 2 converts Part 1's general risk into a causal incident. It gives the series stakes, establishes the recurring failure shape, and creates the need for a system rather than advice.
+
+### Question answered
+
+How can mostly correct code produce research that must be discarded in full?
+
+### Argument chain
+
+1. The first notebook leaked performances across training and test while presenting a clean split at the surface.
+2. The resulting metrics looked strong because the model could exploit information that should have remained unavailable.
+3. Once feature and method decisions had been made against those outcomes, changing the split could not restore independent evidence.
+4. The second notebook inherited a 90-second head-and-tail segmentation default despite a methodology document that warned against that exact strategy. Its immediate defect was plan-to-implementation fidelity: the code violated the written method.
+5. The constant propagated through scripts, fingerprints, clusters, charts, published posts, and a listening study. The broader debt was measurement validity: the convenient unit of analysis silently defined which portion of the music could count as the phenomenon, a problem that merely making later code match a plan would not solve.
+6. The failures share a propagation mechanism but create different methodological debts. Notebook 1 invalidated independence because information crossed a boundary. Notebook 2 first violated its plan and then exposed the separate need to justify that an operational measurement corresponds to the named phenomenon.
+7. Part 3 follows the first debt through the holdout, caches, derivatives, and human adaptation. Part 4 returns to the second debt after a much stronger review process still confuses a consistent measurement chain with the claimed acoustic event.
+8. The attempted deletion that became archival and the request for progress that produced paperwork show the same lower-stakes bias toward plausible forward action.
+9. The human accepted the framing, read the artifacts, published the claims, and incurred social costs before reopening the setup.
+10. The failure is therefore a property of the human-agent system: machine speed and plausible output combine with human trust and commitment.
+11. The improvisation questions encountered during the detour were genuinely interesting but too dependent on disputed labels and operational definitions to yield the clean answer the early work implied.
+12. A compact coda records the immediate response: the first written discipline retired Q01 before audio loaded and forced Q02 into a narrower, caveated claim. This belongs here as contemporaneous history, not as proof that the new process solved validity.
+13. Part 4 owns the later demonstration that those internal gates could still preserve a meaning error. Part 6 owns the mature operating protocol. Part 5 does not inherit Q01 or Q02.
+
+### Claim earned
+
+Research setup is not preliminary plumbing. A hidden split, constant, label definition, or unit of analysis can be the experiment, and downstream correctness cannot repair it.
+
+### Evidence base and status
+
+Contemporaneous user-authored postmortem, retained repository history, invalidated artifacts, methodology documents, and the record of the takedown.
+
+### Required counterarguments
+
+- A competent researcher should inspect their own split and constants.
+- These failures could occur with a junior human assistant.
+- A long checklist may remove the speed benefit that motivated agent use.
+
+The post should concede all three. The author's research background makes the first objection more important, not less: expertise did not remove responsibility or confer immunity. The contribution is the speed and propagation documented inside this human-agent project, not a general causal estimate or the discovery that researchers remain responsible.
+
+### Standalone context requirement
+
+Part 2 must explain the full origin-detour-return chronology, audio question, corpus, and labels in plain language. A standalone reader must learn that automatic set detection was the original goal before the corpus pulled the project into Type I and Type II jam research. The post cannot assume the reader understands those categories or has read Part 1.
+
+### Handoff to Part 3
+
+The two notebooks leave two questions open. Part 3 follows the first: if setup is the experiment, what exactly must be protected, and when does a dataset or artifact stop being independent? The second question, whether the operational measurement represents the phenomenon named in the claim, remains explicitly deferred to Part 4.
+
+### Red-team failure conditions
+
+- The post blames Claude while minimizing the author's approval and publication decisions.
+- The train-test leak and segmentation error become generic cautionary tales without their distinct mechanics.
+- The rules written afterward are presented as a solution before they are tested.
+- Emotional cost substitutes for evidence that the work was invalid.
+- The post tries to explain the full later governance system and steals Part 6's work.
+
+### Removal test
+
+Without Part 2, later governance appears as abstract process enthusiasm. The reader never sees why one locally reasonable choice can require deleting an entire line of work.
+
+## Part 3. The Holdout Is a One-Way Door
+
+### Working title proposition
+
+**Title:** The Holdout Is a One-Way Door
+**Subtitle:** Evidence cannot independently confirm the claim that opening it helped shape.
+
+### Standalone contract
+
+A reader should gain a practical model of leakage as information flow and be able to classify raw files, performances, shows, caches, features, labels, and human adaptation as part of the same boundary.
+
+### Series function
+
+Part 3 provides the first systematic correction to Part 2. It defines the information boundary and explains why the first cleanup was incomplete.
+
+### Question answered
+
+What does it mean for evidence to be independent after an adaptive research process has already begun?
+
+### Argument chain
+
+1. A split is a promise about unavailable information, not a pair of folders.
+2. Audio from the same performance or show can cross the boundary under different filenames, providers, encodings, or track cuts.
+3. Derived features and caches inherit the role and contamination state of their source data.
+4. The later purge removed 1,120 artifacts descended from the two invalid notebooks as a mixed set. The surviving audit does not allocate every file cleanly between the lineages, so the post must not imply lineage-specific counts. Where provenance is established, N1 descendants inherited information contamination and N2 descendants embodied an invalid measurement premise. Part 3 uses only documented N1 examples to explain leakage and leaves documented N2 examples for Part 4.
+5. A check can be perfectly self-consistent and still tautological when the pinned and recomputed values descend from the same mistaken baseline.
+6. The researcher is part of the information path. Outcomes influence feature families, thresholds, aliases, exclusions, stopping decisions, and the stories that seem worth testing.
+7. This is the connection to HARKing: a hypothesis developed after outcomes are seen can remain valuable exploration, but it cannot be represented as independently confirmed by the same outcomes.
+8. A clean boundary therefore requires whole-performance grouping, duplicate control, point-in-time reconstruction, explicit data roles, opaque labels during prediction, frozen hashes, and a record of every opening.
+9. Opened data can support engineering, diagnosis, and genuinely unrelated future questions. It cannot be made sealed again for the affected claim, candidate, or adaptive research lineage by deleting the analyst's memory or starting a new branch.
+10. An adaptive lineage follows causal influence, not repository ancestry. A new question is unrelated only when its claim, candidate, measurement, thresholds, exclusions, and analysis policy do not inherit outcome-specific choices from the opened result. Reusing a raw corpus does not automatically join the lineage; reusing an adaptation learned from its outcomes does. Ambiguous cases default to opened engineering status and record the disputed dependency.
+
+### Claim earned
+
+Independence is a property of the complete provenance and decision history. Once evidence influences design, it permanently loses sealed-confirmation status for the claim, candidate, and adaptive research lineage it shaped. That does not make the data unusable or contaminated for every unrelated future question.
+
+### Evidence base and status
+
+Leak record, cache-contamination erratum, duplicate and performance grouping audits, point-in-time feature rules, sealed execution protocol, and exploration-versus-confirmation literature.
+
+### Required counterarguments
+
+- Perfect isolation may be impossible in a long-running personal project.
+- Small datasets make large sealed sets expensive.
+- Researchers necessarily learn from outcomes.
+- A mixed purge count does not establish how many artifacts belonged to either lineage without a file-level lineage inventory.
+
+The answer is role separation, not amnesia. Opened data remains useful; the claim made from it changes.
+
+### Standalone context requirement
+
+Part 3 should briefly restate the Notebook 1 leak but must not retell both notebook stories. Its independent value is the information-flow model and the claim-scoped permanent data-role rule.
+
+### Handoff to Part 4
+
+Suppose every information boundary is clean, every constant is justified, and every artifact matches the plan. Does that establish that the measurement means what the paper says it means?
+
+### Red-team failure conditions
+
+- Leakage is reduced to duplicate files or incorrect random splitting.
+- The post implies that preregistration eliminates adaptive judgment.
+- Engineering data is described as worthless after opening.
+- The 38-show sealed set is described as evidence before it is opened under the frozen protocol.
+- The post implies that clean independence establishes acoustic truth.
+- N2-derived artifacts are called information-contaminated merely because they were removed in the same purge as N1 descendants.
+
+### Removal test
+
+Without Part 3, the final protocol has no defensible account of why data roles remain permanent within an adaptive research lineage or why a new test split cannot repair development already informed by the affected outcomes.
+
+## Part 4. When Every Check Passes
+
+### Working title proposition
+
+**Title:** When Every Check Passes
+**Subtitle:** All the artifacts agreed. The interpretation had never been tested.
+
+Here, "every check" means every check in the project's defined internal gate sequence. It does not mean every possible validity check.
+
+### Standalone contract
+
+A reader should understand the difference between internal consistency and construct or measurement validity through a case in which an elaborate research discipline approved a result whose interpretation direct listening made suspect.
+
+### Series function
+
+Part 4 pays the second debt opened by Notebook 2. Better data hygiene resolves neither a segmentation procedure that defines the phenomenon by convenience nor a detector that agrees with labels for the wrong acoustic reason. The Dispatch 002 case demonstrates that the correction built after Part 2 shared this blind spot because every reviewer inspected the same derivative chain.
+
+### Question answered
+
+What kind of error survives approved plans, code review, smoke tests, artifact checks, figure checks, prose checks, and an advisor review?
+
+### Argument chain
+
+1. Notebook 2 had already shown that a convenient segmentation procedure could determine what the analysis was capable of observing. The initial cleanup removed the result without fully generalizing the methodological lesson.
+2. The project responded to the lost notebooks by writing R-1 through R-10, assigning agent roles, requiring plans, justifying constants, running smoke tests, logging actions, and obtaining explicit approvals.
+3. Dispatch 002 passed the complete internal process.
+4. The author listened after publication to the first case and made the interpretation suspect because the detected event occurred near track end rather than at the claimed composed return.
+5. The first diagnosis blamed systematically bad labels.
+6. The author then reviewed all ten positive Q23 cases through a one-off listening page. This was a single-rater, outcome-aware check performed after the suspicious case and initial hypothesis were known; it was neither blinded nor a multi-rater agreement study. The preserved case table records eight composed-return marks, one track-end mark, and one rejected mark, while the summary below it incorrectly says nine of ten. The series uses the table, names the contradiction, and concludes only that the systematic-bad-label diagnosis failed. Because only selected positives were reviewed, the exercise cannot estimate false negatives, specificity, or detector-wide construct validity.
+7. The detector selected the final large onset-density change and was therefore biased toward late events. The broader table contains seven hits, all composed returns 36-127 seconds before the archive boundary; its valid Sand miss is only four seconds beyond that range, while the Gin miss uses the track-end label and the Reba mark was rejected. The review invalidates the strong first diagnosis but does not prove the withdrawal summary's track-end-confound explanation.
+8. The labels also permitted more than one operational interpretation, while the analysis silently assumed only one.
+9. Every preexisting gate checked consistency among plan, code, artifacts, numbers, figures, and prose. None checked whether the named event was audible at the relevant moment.
+10. The first check was independent only in evidence modality: it returned to the audio rather than another derivative artifact. It was not independent in evaluator or information history.
+11. The R-11 acoustic reality check was added as a required different evidence path. A later amendment replaced one-off pages with neutral metadata, randomized presentation, no preloaded listener notes, and structured submissions for future checks; that improvement does not retroactively blind the original ten-case review.
+12. Even the erratum required additional evidence because the first explanation of the failure was itself wrong.
+
+### Claim earned
+
+Traceability can prove where a claim came from without proving construct or measurement validity. The interpretation requires direct contact with the underlying phenomenon through a different evidence path, with the evaluator, selection procedure, information exposure, ambiguity, and limits reported explicitly.
+
+### Evidence base and status
+
+Dispatch plan and withdrawal record, full gate history, original labeling instructions, the author's ten-case outcome-aware listening record, and the later neutralized R-11 amendment.
+
+### Required counterarguments
+
+- Listening is subjective and can be primed.
+- Labels can legitimately operationalize a concept differently from a listener's intuition.
+- One spot check is anecdotal.
+
+The post must not imply that the original ten-case review removed priming or supplied inter-rater reliability. It should show that a single outcome-aware listener returned to all ten positive cases and corrected the first diagnosis, then distinguish that historical check from the later neutralized R-11 design for future assignments.
+
+### Standalone context requirement
+
+Part 4 must explain the claimed acoustic event and the review system without requiring knowledge of R-1 through R-10. The event chain matters; the names of every rule do not.
+
+### Handoff to Part 5
+
+Dispatch 002 does not become the recognizer in the next post. Once the jam-research detour exposes its unresolved meaning problem, the project returns to its original automatic song-identification goal. That creates a different question: what counts as valid evidence when the target is no longer an offline research artifact but the behavior of a live application receiving audio through a browser and operating system?
+
+### Red-team failure conditions
+
+- R-11 is presented as a universal solution rather than another fallible measurement process.
+- More agents are presented as the answer even though the agents shared the artifact chain.
+- The first incorrect erratum disappears from the story.
+- Internal consistency is treated as worthless rather than necessary but insufficient.
+- Subjective musical boundaries are forced into false precision.
+
+### Removal test
+
+Without Part 4, the series falsely implies that clean data roles, written plans, and reviewer agents are sufficient. Part 6's independent reality checks would have no demonstrated necessity.
+
+## Part 5. The Browser Is Part of the Experiment
+
+### Working title proposition
+
+**Title:** The Browser Is Part of the Experiment
+**Subtitle:** A model metric cannot validate the system that carries audio to the decision.
+
+### Product/research boundary
+
+SetScope is a viewer-facing song guesser. The song name on screen is a product output, not scientific evidence. The browser and live-show records are product-evaluation material used to diagnose behavior and make release decisions. The series may use that history as support for a narrower methodological claim about deployed-path evaluation, but it must never imply that guessing a setlist is itself a scientific contribution.
+
+### Standalone contract
+
+A reader should understand why a live product can contradict an offline model report, how to localize the failure with transport records, and why end-to-end rehearsals belong to product evaluation rather than ceremonial demonstration.
+
+### Series function
+
+Part 5 marks the return from the jam-research detour to the project's original automatic song-identification target, then moves from measurement validity to execution and transport validity in that deployed system. Dispatch 002 is historical instruction, not a recognizer component. The post also validates the user's repeated insistence that browser behavior mattered more than incremental offline percentage gains.
+
+### Question answered
+
+What was the recognizer actually hearing when the browser demonstration contradicted the model reports?
+
+### Argument chain
+
+1. A historical 46/54 result from five held-out segmented shows was described as roughly 85 percent top one.
+2. That number did not measure continuous capture, premusic behavior, state stability, transitions, unknowns, or publication decisions.
+3. Browser rehearsals produced impossible or contradictory behavior: locks before music, unstable identities, long delays after unanimous votes, and a six-minute run with no admitted music.
+4. The initial temptation was to explain those outcomes as model errors.
+5. The actual deployed path included Chrome, macOS routing, BlackHole, capture, segmentation, resampling, a music gate, several acoustic families, a temporal controller, held state, and the UI.
+6. FFmpeg's AVFoundation capture lost samples, and an earlier resampler inserted periodic digital-zero gaps. Segment timestamps still made the session appear healthy.
+7. Native CoreAudio capture plus source-frame, finalized-sample, and decoded-sample reconciliation exposed transport validity directly.
+8. Exact-byte replay separated model and policy changes from changing audio input.
+9. Once transport was valid, a gate-hysteresis experiment showed a separate state-policy problem without changing the captured bytes.
+10. Two-song and whole-show tests exposed transition, shutdown-drain, catalog, and controller problems that track crops could not express.
+11. A complete product evaluation must therefore include initial-lock precision and coverage, latency, false switches, transition behavior, nonmusic safety, abstention, capture validity, and publication decisions.
+12. The preregistration required one installed candidate and runtime policy to remain unchanged after music began, and the audit records the exercised model and policy versions. No canonical pre-music receipt preserving every required hash, route, mode, publication-state, and start-time field has been located, so the post must distinguish intended frozen conditions from preserved compliance proof. The August 13 canary nevertheless ran prospectively on a genuinely unseen show: because the show had not yet happened, none of its audio or outcomes could have influenced training, model selection, or an earlier test result.
+13. The runtime emitted correct identities for 10 of 12 song performances during the show. A post-show internal acoustic-family diagnosis found 11 of 12, but it is not a second product-capability count. The earned live product observation is the narrower 10-of-12 emitted-output fact.
+14. The run did not yield the frozen whole-show metric it was intended to produce. Set 1 failed the preregistered timebase-integrity gate, and Set 2's later 61.5 percent held-state calculation used approximate post-show boundaries rather than the required frozen, hashed truth timeline.
+15. The remaining post-show diagnostics were still specific and useful: three observed false switches, two observed misses, a debut cover outside the closed catalog, false identity changes inside long jams, correct acoustic evidence blocked by transition policy, and a Set 1 capture gap. They diagnose the product without becoming a preregistered estimate of its accuracy or latency.
+
+### Claim earned
+
+The behavior a viewer experiences belongs to the complete deployed path. A component result cannot predict transport stages, state policies, display rendering, or publication behavior that it never exercised. The live field test showed correct blind controller outputs on future live audio while also showing that the transition controller exercised on August 13 failed specific continuous-state requirements. The preserved record does not establish a UI-observed state or outward chat publication, and this historical live-runtime result does not determine the readiness of a later candidate.
+
+### Evidence base and status
+
+Browser session artifacts, source-frame telemetry, captured waveforms, exact-zero analysis, archive-versus-browser A/B, exact-byte replay, two-song diagnostics, whole-show replay, the August 13 prospective canary and post-show audit, and frozen browser protocols. The August 13 field test is prospective, live-runtime through controller state, shadow, and descriptive rather than metric-eligible for the intended whole-show estimate. No preserved receipt extends it to confirmed display or outward publication scope.
+
+### Required counterarguments
+
+- A few browser runs are not a population-level accuracy estimate.
+- Fixing capture does not improve the classifier by itself.
+- Offline evaluation remains necessary for controlled comparison and coverage.
+
+The post should agree. End-to-end evidence and corpus evidence answer different questions and must be used together.
+
+### Standalone context requirement
+
+Part 5 should define SetScope, its job, and the disputed 85 percent in a compact opening. It should not require the reader to understand the earlier jam-segmentation research.
+
+### Handoff to Part 6
+
+The project has answered the smallest product-capability question by direct observation: a blind system can emit correct song identities during a live Goose show whose audio did not exist when the system was built. It has not produced a valid whole-show accuracy estimate, a viewer-benefit estimate, or an answer to whether the system can maintain reliable current-song state across a catalog and a tour. How can an agent continue improving the product while keeping those open measurements from being silently rewritten as solved?
+
+### Red-team failure conditions
+
+- The browser incident is treated as proof that model quality did not matter.
+- A successful Animal or two-song replay is promoted into product accuracy.
+- Product telemetry is described without explaining what decision it enabled.
+- The original overbroad 85 percent is replaced by another selective metric without its raw denominator.
+- Live demonstration is treated as a substitute for sealed corpus evaluation.
+- A failure of the August 13 controller is written as a readiness verdict about a later candidate.
+
+### Removal test
+
+Without Part 5, the series ends at research artifacts and never shows that a strong offline component result can coexist with an invalid deployed path. The final multi-axis evidence model would be incomplete.
+
+## Part 6. A Discovery Loop That Can Say No
+
+### Working title proposition
+
+**Title:** A Discovery Loop That Can Say No
+**Subtitle:** Bound the agent, preserve the failures, and let claim-specific evidence decide.
+
+### Standalone contract
+
+A reader should receive a reusable operating protocol and a candid account of what that protocol did and did not establish in the recognizer program. The post can be complete before a sealed result exists because its claim is about the operating discipline, not proof that a song guesser is science. It must remain honest if later quantitative evaluations disappoint.
+
+### Series function
+
+Part 6 synthesizes the three case-derived boundaries, reports the strongest current engineering result without laundering it into confirmation, and closes by separating the deployed prototype from the stronger reliability, viewer-benefit, and publication claims still open.
+
+### Question answered
+
+What practical system lets an LLM agent perform substantial empirical work while making evidence roles, permissions, and violations durable and inspectable?
+
+### Argument chain
+
+1. A long instruction is not durable methodology. The model can summarize it, forget distinctions, substitute a shorter goal, or optimize around inconvenience.
+2. The methodology must live in versioned artifacts, explicit data roles, hashes, execution permissions, immutable results, and state transitions.
+3. The useful unit of autonomy is a bounded experiment with a frozen question, permitted inputs, metric, analysis policy, budget, falsifier, and stopping rule.
+4. Planning, execution, and scoring must be separated so labels and outcomes are unavailable when predictions are created.
+5. Negative and invalid results remain in the ledger. They are not overwritten by the next successful run.
+6. Evidence is classified on separate axes: information access relative to the candidate, temporal relation, system scope, publication-action scope, and metric eligibility. Those dimensions cannot substitute for one another.
+7. The August 13 live field test is the first direct runtime answer in chronology and execution: blind recognition emitted correct identities on genuinely future live audio through capture, gating, inference, and controller state. Its failed Set 1 capture gate, missing frozen truth timeline, and absent UI-observation receipt mean that the record remains live-runtime rather than confirmed complete-product evidence and that post-show counts and held-state calculations remain descriptive diagnostics rather than formal performance estimates.
+8. The later v0532 result is a strong outcome-informed engineering result over all 75 opened shows assigned to the engineering side of the frozen v0494 split: 65 correct initial locks by 90 music seconds with ten abstentions, 100 percent selective initial precision, 86.67 percent raw correct coverage, and offline decision-pipeline transition metrics under its recorded policy. The 75 shows are a complete opened engineering population under that protocol, not a representative sample of all Goose performances.
+9. Because the recovery rule was designed after v0531 outcomes were inspected, v0532 cannot establish independent generalization or retroactively repair the August 13 canary. Its larger sample and metric eligibility do not demote the earlier result's prospective status.
+10. The 38-show sealed protocol allows one opening only after the final candidate and all engineering prerequisites are frozen. The 38 were assigned from the same 113 eligible shows by a frozen within-year hash split, without song or outcome inspection. That prevents outcome-based selection and preserves the eligible population's year distribution; it does not establish representativeness beyond the verified corpus. The opening can supply one confirmation result for the frozen candidate; afterward the shows are opened engineering evidence for any adaptive work, whether the candidate passed or failed.
+11. Additional final-candidate complete-product evaluation with display receipts is required before making broad quantitative claims about future user-visible behavior and, if separately authorized, the outward publication path. Repeated future shows do not remain independent confirmation if their outcomes change the candidate or stopping policy.
+12. The final conclusion can say that a viewer-facing prototype exists, emitted correct live identities, and left major measurements open. It cannot call the product useful to viewers without direct or explicitly first-person evidence. If it reports stronger quantitative or publication-readiness claims, it must report the result that occurs, not the ending the series would prefer.
+
+### Claim earned from the current evidence
+
+The project has built a more explicit and auditable process that catches several previously invisible failure classes, sharply limits what current engineering results are allowed to claim, and produced a live fan tool that made correct blind guesses on never-before-existing audio. It has not yet produced a metric-eligible whole-show estimate of reliability, and the product does not need to masquerade as a scientific result for that narrower accomplishment to matter.
+
+### Claim that remains blocked
+
+No present evaluation establishes that the recognizer maintains reliable continuous current-song state across the catalog, benefits viewers, or should be enabled for automatic public setlist publication. Those are stronger product claims and decisions than "the runtime emitted correct identities during one live show."
+
+### Available record and status
+
+Research-discipline history, preregistration/result pairs, immutable hashes, experiment ledger, August 13 live-canary preregistration and audit, v0532 opened-engineering report, and the frozen sealed-execution and browser-rehearsal protocols. No future sealed result or additional final-candidate live record is counted as available.
+
+### The current ending and three possible future updates
+
+**No stronger result yet:** close on the operating protocol and the narrow product fact already observed: SetScope emitted correct guesses during a genuinely new live show, while its broad reliability, viewer benefit, and automatic-publication safety remain open. This is a complete ending for Part 6, not a scientific validation claim.
+
+**Required evidence passes:** report the frozen thresholds, raw denominators, uncertainty, misses, abstentions, slices, sealed result, and final-candidate prospective behavior. The conclusion is that this candidate passed these gates, not that the governance system guarantees truth.
+
+**Mixed result:** report which gates and evidence coordinates passed and failed. A model may clear identity but fail nonmusic safety, clear sealed audio but fail live transport, or maintain precision only by abstaining too often. The series ends with a narrower usable claim.
+
+**Required evidence fails:** report the failure in full and preserve the protocol. The process still has value if its permissions block automatic publication and its durable record makes any attempt to call an opened result sealed explicit and auditable. The final takeaway becomes that a useful research process can preserve an unwelcome result without rewriting its status.
+
+### Required counterarguments
+
+- The governance cost may consume much of the speedup.
+- A single personal project cannot validate a universal methodology.
+- Durable artifacts can become paperwork that is internally consistent but substantively empty.
+- Human approvals can become ceremonial.
+- The highlighted governance catches were selected because they were memorable; without a complete opportunity ledger they do not estimate how often the protocol catches errors or how many it misses.
+
+The post must treat those as continuing risks. The protocol is an operating hypothesis tested by this project, not a finished theory of research automation.
+
+### Standalone context requirement
+
+Part 6 must introduce the three case-derived boundaries, their non-exhaustive scope, SetScope, and the distinctions among product output, evaluation record, and research claim without recapping every incident. A reader should be able to adapt the protocol without mistaking it for a complete validity taxonomy or a validated universal method.
+
+### Ending requirement
+
+The ending must return to the controlling question: which decisions require durable roles, explicit permissions, and evidence outside the agent's artifact chain? It should name the remaining unresolved evidence rather than closing with a generic claim that humans and AI work best together.
+
+Part 6 may be drafted and published without the one-time sealed result because its conclusion is the operating protocol and the distinction among a deployed prototype, a reliability estimate, viewer benefit, and automatic publication. A broad quantitative reliability claim still waits for the one-time sealed result and an appropriately clean complete-product evaluation. A claim that automatic public posting worked additionally requires an actual outward-publication record.
+
+### Red-team failure conditions
+
+- The engineering result is called sealed, out of sample, prospective, or product grade.
+- Selective precision appears without raw coverage and abstentions.
+- Governance artifacts are presented as evidence that the model works.
+- A failed sealed result is omitted, delayed, or reframed as merely another development iteration.
+- The protocol is reduced to multiple agent roles rather than data and evidence boundaries.
+- Part 6 claims the process solved the problem merely because it is elaborate.
+
+### Removal test
+
+Without Part 6, the series diagnoses three case-derived boundaries but never offers or tests a coherent operating response. It would end as a postmortem rather than a research program.
+
+## Part 7. What Happened on the August Run
+
+### Working title proposition
+
+**Title:** What Happened on the August Run
+**Subtitle:** A live product is a history of versions, failures, and emitted guesses, not one score.
+
+### Standalone contract
+
+A reader should understand what SetScope is, how it was used across Goose's eleven-show August 13-28 western run, what each instrumented version emitted or published, how the system changed, which runs were operationally invalid, and what the complete record supports saying about performance. Direct viewer experience remains qualitative unless separately recorded. No knowledge of the notebook failures should be required.
+
+### Series function
+
+Part 7 is the longitudinal product payoff. Parts 1-6 explain how the project learned to distinguish information, meaning, execution, product output, and research claim. The retrospective applies those distinctions to the defined August run without pretending it was one frozen experiment, represented the complete 24-show summer tour, or made the guesser a scientific instrument.
+
+### Question answered
+
+Across Goose's eleven-show August 13-28 western run, how often and how quickly did each SetScope version emit a correct, stable current-song identity, and where did the product path fail?
+
+### Argument chain
+
+1. SetScope's product promise is narrow: emit and display a current-song guess without waiting for an external setlist.
+2. August 13 showed that the task was possible in a real live show, but one run could not describe operation across the full eleven-show August window.
+3. The per-show ledger records the exact product-stratum tuple, run mode, session timebases, audio health, music admission, guesses, state entries and clears, corrections, abstentions, separately receipted UI and publication actions, and post-show truth reconciliation.
+4. Because the product changes during the August run, results must be stratified by stable version and policy. Later repairs cannot be credited to earlier runs, and sparse strata may support only descriptive counts rather than meaningful comparison.
+5. Product behavior has several dimensions: operational availability, identity correctness and coverage, time to first correct guess, time to stable lock, false-switch dwell, abstention, display observation, and public-post behavior.
+6. Capture failures, premusic admission, unknown material, segue ambiguity, recognition errors, controller errors, and outward-publication failures must remain separate even when they all produce a wrong or missing title on screen.
+7. External setlist timing is comparable only when both systems' clocks and events are defined. "First SetScope guess" and "external database ingestion" are not automatically equivalent timestamps.
+8. Memorable song examples can explain mechanisms after the complete denominators are shown; they cannot select the verdict.
+9. Post-show truth version 1 must be reconciled by a different person or clean agent process and hashed without access to SetScope outputs. Outcome-aware truth can support diagnosis but cannot enter the primary post-policy metrics.
+10. Policy v2 freezes the base population and artifact schemas; the prospective v3 addendum resolves report scopes, normalized attempts and restarts, truth corrections and topology, delivery linkage, two-host clock evidence, uniform record envelopes, and additional adversarial vectors before the August 15 show. The invalid v1 pre-freeze draft remains documented rather than being silently relabeled.
+11. The conclusion reports the frozen metrics and the versioned operating profile that occurred without assigning a post-hoc grade.
+
+### Claim available now
+
+As of the frozen ledger snapshot at 2026-08-15 17:41:22 UTC, no reconciled post-policy August-run outcome appears in the record. August 13 is a documented pre-policy pilot; August 14 remains an unreconciled ledger row. The post's prospective collection question, event schema, denominator policy, versioning rule, and possible endings were fixed before the remaining shows.
+
+### Claim available after the tour
+
+The complete, reconciled record may support bounded statements about how SetScope operated during the defined August 13-28 period, under the versions and conditions actually observed. It cannot represent the 13 earlier June-July shows sharing the source tour label. Direct user feedback may support explicitly first-person or qualitative statements about usefulness. Neither becomes a scientific claim about Goose's music or proof that the research protocol generalizes.
+
+### Available record and status
+
+August 13 supplies the first documented case, while August 14 remains an unreconciled pre-policy ledger row. Policy v2 and its prospective v3 addendum freeze the eleven-show August 13-28 western-run population and govern the August 15-28 collection window. The first draft's in-place freeze failure is preserved as an incident rather than treated as prospective evidence. Subsequent show logs, capture telemetry, version manifests, post-show setlists, external observation receipts, and viewer/operator notes are being collected. Results prose waits for completed run states, prediction-blind reconciled truth, and deterministic scoring under that combined policy.
+
+### Four valid result shapes
+
+The retrospective does not assign a post-hoc grade. These scenarios test whether the narrative remains honest:
+
+**Favorable operating profile:** the frozen metrics show frequent correct early locks, little incorrect dwell, and high operational availability. Report the versions, denominators, misses, and remaining failure slices.
+
+**Mixed operating profile:** metrics vary materially by song, show, condition, or version. Report the strata and do not average away the boundary of performance.
+
+**Poor operating profile:** correct locks are late, unstable, sparse, or frequently wrong. Preserve the full record and say so without converting the discussion into a viewer-effect claim.
+
+**Operationally compromised record:** capture, launch, clock, logging, or truth-reconciliation failures prevent a credible August-run estimate. Report product availability and the missing measurement rather than substituting successful anecdotes.
+
+### Required counterarguments
+
+- The software changed too often for one aggregate number.
+- Post-show truth and song boundaries can be approximate, especially around segues.
+- External setlist timestamps may not be semantically comparable.
+- First-person or friend feedback can describe experience but does not estimate a general viewer effect.
+- A product retrospective is not a scientific paper.
+- Truth reconciliation can be biased if the reconciler has seen SetScope's outputs; primary post-policy scoring therefore requires a prediction-blind first truth hash.
+- Frequent software changes may leave version strata too small for comparative claims even when every individual run is valid.
+- The policy and metric window were frozen only after the August 13-14 pilots were observed; it is an outcome-informed product retrospective, not a preregistered eleven-show study.
+- Version strata remain confounded with song, venue, capture condition, and chronology, so their differences are descriptive rather than causal.
+- Capture and stream failures may be informative missingness and must remain in the operating record even when no song opportunity can be scored.
+
+The post should agree with all ten and design its claim accordingly.
+
+### Standalone context requirement
+
+Part 7 must define SetScope, its viewer-facing purpose, the tour and cutoff, the versions included, the product metrics, and the limits of the truth and timing records. It should summarize the methodology history in no more than the context needed to explain why failed runs and changed versions remain visible.
+
+### Red-team failure conditions
+
+- Different versions are pooled into one headline accuracy number.
+- Invalid captures or failed starts disappear from the product-availability denominator.
+- Selective precision appears without coverage, abstention, or valid listening time.
+- SetScope is compared with an external service using incompatible timestamp meanings.
+- Distinctive-song anecdotes decide the aggregate verdict.
+- A useful fan tool is described as scientific validation.
+- Outcome-aware truth or sparse version strata are silently treated as primary comparative evidence.
+
+### Removal test
+
+Without Part 7, Parts 1-6 still form a complete methodological argument, but the series ends after one live field test and never pays off the reader's product question across the August run. The retrospective is the narrative and operational conclusion, not a premise retroactively required to make the earlier posts true.
+
+## 5. Post Independence Matrix
+
+Each post must contain enough local context to stand alone. Independence does not mean repeating the entire series.
+
+| Part | Context it must restate | Concept it must define locally | Independent value | Context it may omit |
+| --- | --- | --- | --- | --- |
+| 1 | None | External judge, research-like form, publication context, exploration vs confirmation | Framework for evaluating LLM-mediated research claims across formal and informal publication contexts | Detailed construct-validity adjudication and audio history |
+| 2 | Audio question, corpus, two notebook goals | Setup decision, leakage, segmentation | Concrete postmortem for agent-assisted empirical work | Field-wide literature survey |
+| 3 | One-paragraph Notebook 1 recap | Information flow, data role, opened vs sealed | Practical model of leakage and adaptive analysis | Dispatch 002 and browser path |
+| 4 | Brief origin of the governance rules | Internal consistency, construct validity, operationalization | Why review chains can agree on the wrong construct | Detailed split mechanics and live product architecture |
+| 5 | SetScope purpose and disputed historical metric | Component metric, transport validity, complete-product evidence | End-to-end evaluation and observability case | Jam taxonomy and full rule history |
+| 6 | SetScope, the case-derived three-boundary model, current evidence status | Bounded experiment, evidence coordinates, immutable result | Reusable protocol plus a prospective result whose evidentiary limits remain explicit | Full incident reconstructions |
+| 7 | SetScope purpose, August-run cutoff, version history | Product availability, versioned field record, comparable clocks | Honest longitudinal product retrospective | Detailed notebook, governance history, and earlier summer shows |
+
+Every post must provide:
+
+1. one explicit question;
+2. one concrete incident or evidence base;
+3. one distinction the reader can reuse;
+4. one conclusion the evidence supports;
+5. one limitation preventing a stronger conclusion; and
+6. one sentence explaining what remains unresolved.
+
+## 6. Handoff Integrity
+
+The end of each post should create a real unresolved problem, not advertise the next installment.
+
+| Handoff | Premise carried forward | New question | Invalid shortcut |
+| --- | --- | --- | --- |
+| 1 to 2 | Independent judgment separates acceleration from self-confirming form | What does self-confirmation look like in practice? | Repeating citation hallucinations as the personal failure |
+| 2 to 3 | The two notebooks create different debts; Notebook 1 concerns information independence | What information must be kept outside the design loop? | Treating a better random split as the complete repair or pretending it also resolves Notebook 2 |
+| 3 to 4 | Clean information boundaries can support independent evaluation | Does the measurement correspond to the named phenomenon? | Treating preregistration as construct validation |
+| 4 to 5 | The jam-research detour has exposed a meaning failure; the project now returns to its original automatic song-identification goal | What evidence describes the input path and behavior of the deployed recognizer? | Pretending Dispatch 002 became a validated recognizer component or treating one listening check as product evaluation |
+| 5 to 6 | Complete-product behavior must be described on multiple evidence axes | How are all boundaries enforced during autonomous work? | Treating observability or browser testing as the entire protocol |
+| 6 to 7 | A deployed prototype, a reliability estimate, viewer benefit, and automatic publication are separate outcomes | What did the instrumented product path actually emit across the defined eleven-show August run? | Treating one live show, one frozen model, or one aggregate score as the August-run story |
+
+## 7. Terminology That Must Not Drift
+
+### Output, artifact, evidence, and claim
+
+- **Output:** anything produced by a model, script, person, or instrument.
+- **Artifact:** a persisted output with provenance.
+- **Evidence:** an artifact or observation that is valid for a specified question under a specified design.
+- **Claim:** the interpretation the author asks the evidence to support.
+
+The series should never use these as synonyms. A large artifact set is not automatically a large evidence base.
+
+### Reproducibility and replicability
+
+- **Computational reproducibility:** the same data, code, and method produce a consistent result.
+- **Replicability:** a new study aimed at the same scientific question produces a consistent result.
+
+The series uses reproducibility as necessary provenance, not proof of scientific validity.
+
+### Exploration and confirmation
+
+- **Exploration:** outcomes may influence what is tried, retained, or interpreted.
+- **Confirmation:** the question, candidate, metric, and analysis policy are frozen before the confirming outcomes are exposed.
+
+Exploration is not a lesser moral category. It supports a different claim.
+
+### Internal consistency, construct validity, and execution validity
+
+- **Internal consistency:** plan, implementation, artifacts, numbers, figures, and prose agree.
+- **Construct or measurement validity:** the operational measurement and its interpretation correspond to the phenomenon named in the claim.
+- **Execution or transport validity:** the deployed system receives and processes the phenomenon through the path the evaluation assumes.
+
+The series should not redefine the broader statistical term *external validity* to cover either of these questions. It should name construct or measurement validity in Part 4 and execution or transport validity in Part 5.
+
+### Evidence coordinates, not evidence buckets
+
+The project previously treated *engineering*, *sealed*, *prospective*, *browser*, and *product* as though they were alternatives. They are not. They describe different axes, and one evidence item occupies a position on every relevant axis:
+
+1. **Information access relative to the candidate:** *opened/adaptive* outcomes are available for diagnosis or have influenced development; *unavailable-at-freeze* outcomes could not influence the frozen candidate. Historical data can be unavailable through a sealed policy; genuinely future data can be unavailable because the event does not yet exist. Once either outcome is inspected, it is opened for later candidates even though the original frozen run retains its historical status.
+2. **Temporal relation:** *retrospective* evidence predates or was available before the candidate and policy were frozen; *prospective* evidence arrives afterward. A future event can become opened engineering evidence for later candidates once it is inspected.
+3. **System scope:** *component* evidence exercises one model or isolated stage; *integrated-offline* evidence exercises the decision pipeline over recorded inputs while bypassing live transport and display; *live-runtime* evidence exercises actual capture, gates, inference, and controller state; *complete-product* evidence additionally preserves a receipt for the user-visible state. A browser session reaches only the last stage for which a receipt survives.
+4. **Publication-action scope:** *shadow* evidence may exercise the publication decision logic but disables the outward write; *publication-path* evidence includes the actual user-visible or automatic outward action.
+5. **Metric eligibility:** *descriptive/diagnostic* evidence can establish that an event occurred and expose failure modes; *metric-eligible* evidence satisfies the frozen capture, truth, denominator, and scoring requirements for a stated performance estimate.
+
+For the frozen canary candidate, August 13 was unavailable-at-freeze, prospective, live-runtime evidence through controller state. Its saved observations are descriptive rather than metric-eligible for the intended whole-show estimate. Once the post-show setlist and traces were reviewed, the show became opened/adaptive evidence for every later candidate; that does not erase what the original prospective run demonstrated. The preserved audit calls the sessions shadow traces, the preregistration disabled authoritative setlist and marker writes, and no UI-observation or chat-delivery receipt appears in the reviewed artifacts. The available record therefore does not support confirmed display or outward-publication scope. No percentage or claim should appear without the coordinates that justify its use.
+
+### Model, agent, and system
+
+- **Model:** fitted or prompted component producing an output.
+- **Agent:** a model operating with tools, context, and authority over actions.
+- **System:** people, agents, code, data, infrastructure, interfaces, policies, and incentives together.
+
+Responsibility and failure claims should identify which level they concern.
+
+## 8. Evidence Architecture
+
+The series should make the role of evidence visible, not merely cite a large quantity of it.
+
+| Evidence | Design or coordinates | Supports | Does not support |
+| --- | --- | --- | --- |
+| Published citation and review studies | External literature; retain each source's study design and population | Existence and estimated prevalence of specified LLM-mediated behaviors | Attribution of every suspicious paper or review to AI |
+| Private adjacent-project methodology audit | Private editorial fact-checking; not a public anonymous evidence object | Existence of a serious, transparent, science-shaped data product published outside a formal academic venue; material for a possible separately attributed critique | Part 1's construct-validity argument, hidden implementation details, proof that its labels are wrong, creator affiliation, public inspectability, or permission to identify the project |
+| Two-notebook repository record | Retrospective, opened historical record; descriptive | What failed in this project and how artifacts propagated | Population claims about all LLM-assisted research |
+| Provenance and split audits | Retrospective audits of information access and adaptation history | Information roles and contamination findings | Construct validity or product accuracy |
+| Author's original ten-case audio review | Opened, retrospective, different modality, single outcome-aware evaluator, descriptive | Whether this listener heard the claimed event in the ten selected positive Q23 cases; evidence that corrected the first diagnosis | Blinded judgment, inter-rater reliability, evaluator independence, or population-level validity |
+| Later neutralized R-11 protocol | Prospective design specification; no result by itself | A more reproducible design for future acoustic-reality checks using neutral metadata, randomized presentation, and structured submissions | Retroactive blinding of the original review or proof that one listener's construct is shared |
+| Offline whole-show replay | Information access and metric eligibility vary by run; retrospective; integrated-offline scope without live transport | Behavior over opened or sealed recorded shows under a specified runtime | Live capture reliability or future-show performance unless the design supports it |
+| Browser capture telemetry | Information and temporal status vary by run; live-runtime through controller state, extending to complete-product only with a display receipt; shadow or publication action stated separately | Integrity and decisions through the last receipted stage | Broad catalog accuracy from a few rehearsals or unreceipted display behavior |
+| v0532 engineering result | Opened/adaptive, retrospective, integrated-offline, shadow, metric-eligible for its recorded engineering question | Performance of an outcome-informed candidate on 75 opened shows | Independent generalization, live transport, UI behavior, or outward publication |
+| Future sealed result | Unavailable-at-freeze through the seal for one candidate; retrospective; integrated-offline; no outward publication action; metric-eligible if gates pass | That candidate's performance on the defined sealed population | Future-tour representativeness, live transport, unlimited future validity, or automatic publication safety |
+| August 13 prospective live canary | Unavailable-at-freeze and prospective for the canary candidate; opened/adaptive for later candidates after post-show review; live-runtime through controller state; shadow; descriptive rather than metric-eligible for the intended whole-show estimate | The temporally independent fact that dateless, setlist-free recognition emitted correct identities during one future show; saved runtime failure modes | Confirmed UI delivery, a whole-show accuracy or latency estimate, catalog-wide reliability, exercised outward publication, or launch readiness |
+| Additional final-candidate prospective operation | Unavailable-at-freeze and prospective relative to a frozen final candidate; complete-product if a display receipt survives, otherwise live-runtime through the last receipted stage; shadow or publication-path as stated; metric eligibility depends on frozen capture and truth gates | Real future behavior through the last independently receipted deployed stage and specified action policy | Correctness of unobserved decisions or later candidates after adaptation |
+| August-run field ledger | Versioned longitudinal product record; information and metric status stated per run; all reviewed outcomes opened for subsequent versions | Operational behavior of the recorded versions during the August 13-28 window, plus display or publication behavior only when separately receipted | One frozen-candidate accuracy claim, the 13 earlier summer shows, unobserved shows, future-tour reliability, scientific claims about the music, or universal protocol validity |
+
+### SetScope coordinate inventory
+
+| Item | Information access | Temporal | System scope | Publication action | Metric status |
+| --- | --- | --- | --- | --- | --- |
+| Historical 46/54 segmented result | Leakage-disjoint for the exact 54 rows at file, performance, and show-date levels | Retrospective | Component crops | None | Eligible only for its narrow 45-label segmented sample; not live accuracy |
+| Corrupt browser sessions | Opened/adaptive | Retrospective rehearsal | Complete-product attempted, invalid capture | Shadow | Invalid for recognition metrics; diagnostic incident |
+| Repaired native-capture browser sessions | Opened/adaptive | Retrospective rehearsal | Live-runtime or complete-product according to preserved UI receipt | Shadow | Diagnostic unless the named run satisfies frozen truth and capture gates |
+| Animal exact-byte gate A/B | Opened/adaptive | Retrospective | Integrated-offline replay | Shadow | Diagnostic comparison, not live-system evidence |
+| Dr. Darkness to Drive browser run | Opened/adaptive | Retrospective rehearsal | Live-runtime or complete-product according to preserved UI receipt | Shadow | Diagnostic two-song incident |
+| Dr. Darkness to Drive exact-byte replay | Opened/adaptive | Retrospective | Integrated-offline replay | Shadow | Diagnostic policy comparison |
+| August 13 canary | Unavailable-at-freeze for canary; opened for later candidates | Prospective | Live-runtime through controller state; no preserved UI-observation receipt | Shadow | Descriptive, not eligible for intended whole-show metric |
+| v0532 75-show result | Opened/adaptive | Retrospective | Integrated-offline | Shadow | Eligible for frozen engineering question only |
+| v0532 browser-rehearsal protocol | Not an outcome | Future design | Intended complete-product | Shadow unless separately authorized | No behavioral result yet |
+| 38-show sealed protocol | Unavailable-at-freeze if provenance remains clean | Retrospective audio | Intended integrated-offline | None | No result yet |
+| August-run ledger | Varies by version before each show; opened for every later adaptive version after review | Prospective operation accumulated from August 13-28 | Live-runtime, display, or publication scope stated per receipted stage; invalid operation otherwise | Shadow or publication-path stated per run | Ongoing; eligibility determined per capture session, song opportunity, and aggregate policy |
+
+### Editorial artifact index
+
+The public prose will need durable, reader-accessible citations or archived excerpts where appropriate. During outline review, the canonical local artifacts are:
+
+- Notebook source and immediate Q01/Q02 response: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_drafts/two-notebooks-lost.markdown`
+- Earliest surviving live-song timing preregistration located during this audit: `/Volumes/Zabriskie Work/repos/zabriskie-audio-local-resume/tools/audio_detection/cloud/v0135-live-timebase-fusion-preregistered.md`, committed July 30, 2026. It corroborates the later return to live song recognition but does not independently establish that set detection preceded the jam-research detour; that ordering remains the author's first-person chronology.
+- Cache-contamination erratum: `/Users/cmeiklejohn/GitHub/zabriskie-audio-research/docs/logs/r7-errata-2026-05-17-cache-contamination.html`
+- Dispatch 002 withdrawal: `/Users/cmeiklejohn/GitHub/zabriskie-audio-research/docs/logs/dispatch-002-withdrawal.html`
+- Research-discipline history: `/Users/cmeiklejohn/GitHub/zabriskie-audio-research/docs/research-discipline.html`
+- Neutralized R-11 assignment protocol: `/Users/cmeiklejohn/GitHub/zabriskie-audio-research/supabase/migrations/20260524000000_seed_draw1_r11_decoupling_check_v1.sql`
+- R-11 plan lock: `/Users/cmeiklejohn/GitHub/zabriskie-audio-research/artifacts/draw1/r11_plan_lock_submission.json`
+- Browser-capture incident: `/Volumes/Zabriskie Work/repos/zabriskie-audio-local-resume/tools/audio_detection/cloud/v0506-browser-capture-input-integrity-incident.md`
+- August 13 preregistration and audit: `/Volumes/Zabriskie Work/repos/zabriskie-audio-local-resume/tools/audio_detection/cloud/v0519-2026-08-13-prospective-live-canary-preregistered.md` and `v0521-2026-08-13-live-show-audit.md`
+- v0532 preregistration and result: `/Volumes/Zabriskie Work/repos/zabriskie-audio-local-resume/tools/audio_detection/cloud/v0532-continuous-unknown-recovery-preregistered.md` and `v0532-continuous-unknown-recovery-result.md`
+- Sealed execution protocol: `/Volumes/Zabriskie Work/repos/zabriskie-audio-local-resume/tools/audio_detection/cloud/v0512-sealed-confirmation-execution-protocol.md`
+- August-run retrospective policy v2: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_drafts/setscope-summer-tour-2026-retrospective-policy.md`
+- Prospective policy v3 addendum: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_drafts/setscope-summer-tour-2026-policy-v3-addendum.md`
+- Policy v3 machine contract: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_data/setscope_summer_tour_2026_v3_addendum.yml`
+- Invalid v1 freeze incident: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_drafts/setscope-summer-tour-2026-policy-v1-freeze-incident.md`
+- Frozen August-run manifest: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_data/setscope_summer_tour_2026.yml`
+- Ongoing version and run-validity ledger: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_data/setscope_summer_tour_2026_runs.yml`
+- Frozen run-record schema: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_data/setscope_summer_tour_2026_run_schema.yml`
+- Frozen event, truth, UI, external-observation, and scoring-report schemas: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_data/setscope_summer_tour_2026_artifact_schemas.yml`
+- Frozen scoring derivation and adversarial vectors: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_data/setscope_summer_tour_2026_scoring_spec.yml`
+- Policy, manifest, and schema digests: `/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/_drafts/setscope-summer-tour-2026-retrospective-policy.sha256`
+
+## 9. Deliberate Repetition And Forbidden Repetition
+
+Some ideas must recur because they are the throughline. They should gain meaning each time.
+
+### Deliberate recurrence
+
+- **The surface looks complete:** scholarly prose in Part 1, notebooks in Part 2, audit trails in Part 4, percentages and UI in Part 5.
+- **The outside judge:** primary sources and evaluators in Part 1, split audits in Part 3, audio in Part 4, source frames and complete-product scoring in Part 5, sealed and prospective evidence in Part 6. Each judge still requires an independence and construct check of its own.
+- **The human remains inside the system:** trust in Part 2, adaptation in Part 3, primed diagnosis in Part 4, insistence on browser tests in Part 5, approval and veto limits in Part 6.
+- **Failure must change status:** invalid notebooks, contaminated caches, withdrawn dispatch, invalid browser sessions, opened engineering results, final sealed verdict.
+- **The product remains concrete:** the original song-guesser ambition in Part 2, the browser path in Part 5, the narrow live result in Part 6, and the versioned tour outcome in Part 7.
+
+### Forbidden repetition
+
+- Part 3 must not retell Notebook 2 at length; it must identify that failure as a separate debt deferred to Part 4.
+- Part 4 must briefly reconnect its meaning problem to Notebook 2 rather than presenting Dispatch 002 as an unrelated new lesson.
+- Part 4 must not re-explain generic data leakage.
+- Parts 4 and 5 must not use "external validity" as a vague label for construct, transport, capture, and integration questions that can be named more precisely.
+- Part 6 must not repeat every incident before presenting the protocol.
+- No post after Part 2 should rediscover that setup matters as if it were a new conclusion.
+- No post may end with the same generic instruction to "keep a human in the loop."
+
+## 10. Counterargument Map
+
+An adversarial review should verify that the series encounters these objections at the point where they are strongest.
+
+| Objection | Required location | Required answer |
+| --- | --- | --- |
+| Humans make all of these errors | Parts 1 and 2 | Yes. The general point is not uniquely machine-created misconduct; the case-specific claim concerns rapid propagation, plausible surface quality, and changed supervision demands in this project. |
+| The adjacent example is a fan product, not a paper | Part 1 | Yes. That is the point: a serious science-shaped artifact can exist outside the institutions where research-quality debates are usually located. It is not presented as misconduct, proof of invalidity, or evidence that its creator used an LLM. |
+| An anonymous example cannot be independently inspected by the reader | Part 1 | Correct. The public post may use it only as a nonessential illustration of a category already supported elsewhere. The private dossier preserves the source for editorial audit; the series' substantive validity argument comes from the author's named case. |
+| There is no counterfactual for how much time the LLM saved | Parts 1 and 2 | Correct. Treat "weeks into hours" as the author's documented project estimate, not a causal productivity measurement or population claim. |
+| One person's labels can still be excellent | Part 4 | Yes. Reliability is unmeasured, not disproven. Expertise and agreement answer different questions, and the series' own labels require the same scrutiny. |
+| The notebooks failed because the author did not review the work | Part 2 | Yes. Human responsibility is part of the causal system, not a rebuttal to it. |
+| Preregistration and clean splits solve the problem | Parts 3 and 4 | They protect confirmation and information boundaries but do not establish construct validity. |
+| Listening is subjective | Part 4 | Report that the historical ten-case check used one outcome-aware author-listener and therefore did not estimate agreement. Preserve ambiguity, and describe neutral presentation or multiple raters as stronger future designs rather than properties of the original evidence. |
+| A frozen plan can preserve a bad construct more efficiently | Parts 4 and 6 | Yes. Durability protects provenance and permissions; it does not establish meaning. A different evidence path must still challenge the construct. |
+| Browser demonstrations are anecdotal | Part 5 | They diagnose product-path validity; they complement rather than replace corpus evaluation. |
+| Correct identity at least once may have little product value | Part 5 | Yes. The August discovery counts demonstrate capability, while held state, latency, false switches, abstention, and publication behavior describe the rest of the product path. Viewer benefit remains a separate question. |
+| An elaborate protocol can become performative paperwork | Parts 4 and 6 | It already did. The protocol matters only when it changes permissions, catches failures before propagation, and preserves sealed and final-candidate prospective outcomes without relabeling them. |
+| Governance erases the speed advantage | Part 6 | Possibly. The series should measure and admit the tax rather than assert a free reliability gain. |
+| A clean sealed set can still be unrepresentative | Part 6 | Correct. A sealed result supports only its defined sampling frame and population. It does not establish future-tour or catalog-wide performance without a defensible connection to that population. |
+| Repeated future shows remain prospective confirmation | Part 6 | Not automatically. A show's temporal status is prospective relative to a frozen candidate, but once outcomes influence revisions or stopping, it becomes opened engineering evidence for later candidates. |
+| One case study cannot prove a general method | Part 6 | Correct. The result is an operating protocol and set of failure mechanisms, not a universal causal estimate. |
+
+## 11. Series-Level Claims And Falsifiers
+
+### Claim A: In this project, LLM assistance rapidly propagated invalid empirical premises
+
+**Support required:** the project's documented implementation speed, silent methodology decisions, rapid downstream propagation, and evidence that the invalidity was substantive rather than cosmetic.
+
+**Falsifier or narrowing evidence:** the case does not establish a population-level causal effect of LLM use. If the incidents cannot be separated even locally from ordinary project haste, state only that this human-agent system produced and propagated invalid work quickly.
+
+### Claim B: Durable boundaries improve auditability and constrain automatic action
+
+**Support required:** concrete cases in which role restrictions, frozen plans, provenance, label blindness, or validation gates created an inspectable record, blocked an automatic action, or caught a problem before broader propagation. Existing examples include Q01 halting before audio loaded and the August canary keeping authoritative setlist and marker writes disabled; the post must distinguish those recorded constraints from broader claims about prevention.
+
+**Falsifier or narrowing evidence:** if the rules only generate documentation after the same mistakes, the claim narrows to traceability. The architecture does not claim that these boundaries guarantee prevention or that people cannot ignore them.
+
+### Claim C: SetScope emitted correct live song identities
+
+**Support available for the narrow version:** the August 13 field test, in which the runtime emitted correct blind song guesses during a genuinely new live show, together with the saved trace and its documented failures.
+
+**Current permitted version:** SetScope emitted the correct identity at least once for 10 of 12 recorded song performances during one live show. This is a product observation, not a whole-show accuracy, duration, display-delivery, viewer-benefit, or catalog-wide reliability claim.
+
+**Support required for a stronger version:** clean complete-product and corpus evaluations across identity, latency, transitions, abstention, nonmusic, and capture integrity. Automatic-publication readiness also requires the relevant operational safety decision and outward-path record.
+
+### Claim D: The protocol generalizes beyond this project
+
+**Support required for a strong version:** use in other empirical projects or independent adoption and evaluation.
+
+**Current permitted version:** the protocol exposes reusable questions and mechanisms that other practitioners can test. The series does not yet establish cross-project efficacy.
+
+## 12. Title And Takeaway Alignment
+
+The title/subtitle pair for each post should be testable against one sentence.
+
+| Part | Proposition the title must carry | One-sentence takeaway |
+| --- | --- | --- |
+| 1 | Research-like output is cheap; validity still requires an outside judge | Ask what independently judges the output, not whether an AI touched it. |
+| 2 | Setup decisions are experimental decisions | Correct downstream work cannot rescue an invalid premise. |
+| 3 | Opened evidence cannot independently confirm the claim it helped shape | Data roles follow information flow within an adaptive research lineage, including human adaptation and derivatives. |
+| 4 | Internal agreement can preserve a shared mistake | Check the named construct against the underlying phenomenon. |
+| 5 | Product behavior belongs to the complete path | Measure what the deployed system heard and did, not only what a component can do offline. |
+| 6 | Auditable autonomy is bounded and evidence-led | Freeze permissions, preserve failures, and let claim-specific evidence determine what may be said. |
+| 7 | A live product is a versioned operational history | Report how the evolving tool operated using the complete August-run record, not one score or a few memorable songs. |
+
+An adversarial agent should flag any title that promises a more dramatic result than the post earns, and any post whose actual conclusion cannot be stated in its title or subtitle without qualification.
+
+## 13. Adversarial Reader Scenarios
+
+The architecture should survive at least these readers:
+
+1. **The AI optimist:** looks for selective treatment of positive and negative AI evidence.
+2. **The AI skeptic:** looks for cases where ordinary human research error is rhetorically blamed on a model.
+3. **The statistician:** looks for adaptive selection, denominator changes, unsupported generalization, and uncertainty omitted from claims.
+4. **The measurement researcher:** looks for proxies receiving construct names without validation and for reliability being confused with validity.
+5. **The music-domain expert:** looks for false precision around jam boundaries, segues, composition, and listener disagreement.
+6. **The product engineer:** looks for offline metrics presented as end-to-end behavior and for observability without acceptance decisions.
+7. **The source-project author:** looks for a fair, non-identifying account of stated purpose, acknowledged limitations, and which claims actually depend on hand labels.
+8. **The reader who starts with Part 4:** needs enough project context to understand the failed gate system without Parts 1 through 3.
+9. **The reader who only reads Part 6:** needs a usable protocol and an honest evidence status without the emotional force of the preceding narrative.
+10. **The reader after a failed sealed evaluation:** should find that the series still makes sense and has not promised a successful recognizer from the beginning.
+11. **The product reader:** should never be asked to mistake a viewer-facing song guesser, a field-test log, and a scientific result for the same thing.
+12. **The tour reader:** should be able to tell which product version ran, whether the audio path was healthy, what viewers saw, and which denominator supports every aggregate.
+
+## 14. Adversarial Audit Protocol
+
+The adversarial reviewer is evaluating argument integrity, not style. It should not rewrite titles, reorder paragraphs, or reward rhetorical smoothness. It should assume that a polished draft can hide a broken dependency.
+
+### Required inputs
+
+Provide the reviewer with:
+
+1. this architecture document;
+2. the canonical editorial plan;
+3. the Part 1 source dossier;
+4. all available post drafts;
+5. the evidence artifacts named by each post;
+6. the current status of the sealed and prospective evaluation; and
+7. for Part 7, the frozen tour manifest and scoring policy plus the current per-run version, validity, delivery, truth, and external-observation records.
+
+Do not provide a prose summary in place of these files. The reviewer should inspect the source artifacts directly.
+
+### Review stages
+
+#### Stage 1: Claim extraction
+
+Extract every substantive series-level and post-level claim. For each, identify:
+
+- the exact wording;
+- the evidence cited;
+- the population and conditions;
+- whether the claim is descriptive, causal, predictive, interpretive, or normative;
+- whether the claim was known at the time of the event or learned later; and
+- the strongest narrower claim the evidence certainly supports.
+
+#### Stage 2: Dependency audit
+
+For every conclusion, identify the premises it requires. Flag:
+
+- a premise not established in the same or an earlier post;
+- a premise established only by a later result;
+- a post that repeats a prior conclusion without adding a new boundary;
+- a transition that turns chronology into causality; and
+- a conclusion that depends on the reader remembering undefined context from another post.
+
+#### Stage 3: Evidence-role audit
+
+Classify every project evidence item on each applicable axis: information access relative to the candidate, temporal relation, system scope, publication-action scope, and metric eligibility. External literature and domain reality checks should be named by source and design rather than forced onto those project-execution axes. Flag any unmarked change of coordinate or substitution between axes, including:
+
+- opened engineering metrics described as generalization;
+- browser anecdotes described as population accuracy;
+- reproducibility described as validity;
+- inter-rater absence described as label error;
+- a proxy score described as the construct itself; and
+- selective precision presented without coverage and abstentions.
+
+#### Stage 4: Standalone audit
+
+Read each post in isolation. Score whether it provides:
+
+- the question;
+- necessary project context;
+- definition of its central distinction;
+- concrete evidence;
+- an earned takeaway;
+- limitations; and
+- value to a reader who never opens another post.
+
+#### Stage 5: Throughline audit
+
+Read the series in order and test whether the reader's model changes exactly once at each post:
+
+1. cheap research-like production requires an outside judge;
+2. setup is the experiment;
+3. independence is an information history;
+4. internal consistency is not construct or measurement validity;
+5. component validity is not system validity;
+6. bounded autonomy makes those evidence distinctions auditable and limits automatic action; and
+7. a longitudinal product result must preserve versions, operating failures, clocks, and viewer-visible behavior.
+
+Flag missing steps, collapsed boundaries, repeated revelations, and any post that does not make the next post necessary.
+
+#### Stage 6: Ending audit
+
+Run Part 6 against no sealed result yet, sealed pass, mixed result, and sealed fail. Then run Part 7 against a favorable, mixed, poor, and operationally compromised August-run record. Flag any earlier sentence that becomes misleading under one of those outcomes. The series passes this stage only if its methodological thesis survives every outcome and the product conclusion changes appropriately.
+
+### Required output
+
+The reviewer should return:
+
+1. **Overall verdict:** `coherent`, `coherent with revisions`, or `broken`.
+2. **Critical breaks:** unsupported dependencies that invalidate the progression.
+3. **Post contract table:** pass or fail for standalone value, distinct claim, handoff, title alignment, and evidence role.
+4. **Claim ledger:** each claim with evidence, permitted wording, and overclaim risk.
+5. **Redundancy report:** material that belongs to another post or performs no new logical work.
+6. **Missing counterarguments:** the strongest reasonable objection not answered where it arises.
+7. **Boundary-confusion report:** places where information, meaning, and execution validity are conflated.
+8. **Ending robustness:** pass, mixed, and fail scenarios.
+9. **Minimum repairs:** the smallest architectural changes required before prose revision.
+10. **Questions for the author:** unresolved factual or interpretive choices the reviewer must not decide silently.
+
+### Copyable adversarial prompt
+
+```text
+You are an adversarial argument reviewer, not a writing coach. Review the attached
+series architecture, editorial plan, drafts, source dossier, and named evidence
+artifacts. Do not improve the prose. Do not propose prettier titles. Do not infer
+that a claim is supported because it sounds reasonable or because several
+artifacts agree with one another.
+
+Your job is to determine whether the seven-post series forms one complete logical
+progression while each post remains independently useful.
+
+Treat these as distinct and non-substitutable:
+1. information independence;
+2. construct or meaning validity;
+3. deployed execution validity;
+4. the orthogonal evidence axes: information access relative to the candidate, temporal relation, system
+scope, publication-action scope, and metric eligibility.
+5. a user-facing song guess, a product field-test record, and a research claim about the development process.
+
+SetScope is an ordinary fan-facing song guesser. Its displayed guesses are
+product outputs, not scientific findings. Audit whether the series preserves
+that distinction while still applying rigorous evaluation discipline to any
+quantitative reliability or automatic-publication claim.
+
+For every substantive claim, state the evidence, population, conditions, claim
+type, and strongest narrower wording certainly supported. Flag chronology used
+as causality, an opened result represented as confirmation, computational
+reproducibility represented as scientific validity, lack of inter-rater evidence
+represented as label error, a proxy represented as its construct, and selective
+precision reported without coverage.
+
+Read every post twice: once alone and once in series order. A standalone post
+must define its question and distinction, supply enough local context, present
+concrete evidence, earn one takeaway, and state the limit on that takeaway. In
+series order, each post must add exactly one necessary rung:
+
+P1: cheap research-like production requires an outside judge.
+P2: setup is the experiment.
+P3: independence is an information history.
+P4: internal consistency is not construct or measurement validity.
+P5: component validity is not complete-product validity.
+P6: bounded autonomy makes those distinctions auditable, limits automatic
+action, and submits claims to the evidence coordinates and gates they require.
+P7: a tour retrospective preserves product versions, operating failures, clocks,
+and viewer-visible behavior instead of collapsing them into one score.
+
+Test Part 6 with no sealed result yet, a pass, a mixed result, and a fail. Test
+Part 7 with a favorable, mixed, poor, and operationally compromised August-run record.
+Flag any earlier promise that makes one of those honest endings impossible.
+
+Return:
+- overall verdict: coherent, coherent with revisions, or broken;
+- critical logical breaks, ordered by severity;
+- a per-post contract table;
+- a claim and evidence ledger;
+- repeated or misplaced material;
+- missing counterarguments;
+- conflated validity boundaries;
+- standalone failures;
+- ending robustness for every Part 6 and Part 7 outcome;
+- the minimum architectural repairs required;
+- factual or interpretive questions that must go back to the author.
+
+Prefer a direct finding over a balanced-sounding paragraph. Do not silently fix
+the series on the author's behalf.
+```
+
+## 15. Acceptance Criteria Before Full Drafting
+
+The architecture is ready for prose work only when an adversarial review finds:
+
+- no critical dependency break in S1 through S7;
+- a distinct claim and removal justification for all seven posts;
+- standalone context, takeaway, and limitation for every post;
+- no unmarked change on or substitution among information, temporal, system-scope, publication-action, and metric-eligibility axes;
+- no conflation of information, meaning, and execution boundaries;
+- no title or subtitle that promises more than the post earns;
+- no conflation of a SetScope guess, a product field-test record, and a scientific or methodological claim;
+- a fair, source-grounded, and non-identifying adjacent-project example whose only argumentative job is showing a science-shaped artifact published outside a formal academic venue;
+- a Part 6 ending that remains honest with no sealed result yet and under pass, mixed, or fail;
+- a Part 7 architecture that remains honest under a favorable, mixed, poor, or operationally compromised August-run record; and
+- explicit unresolved questions returned to the author rather than decided by an agent.
+
+## 16. Current Open Decisions
+
+The seven-post length is now justified as a six-post methodological arc plus a final longitudinal product retrospective. Parts 1-6 are architecturally ready for prose; Part 7 is architecturally ready but its results prose intentionally waits for the August-run record. The remaining factual or product decisions are:
+
+1. How much of the existing user-authored *Two Notebooks Lost* draft should remain unchanged. No rewrite should occur without explicit approval.
+2. What the final frozen SetScope candidate is, whether the 38-show sealed set remains clean against its complete provenance, and whether execution is authorized.
+3. What target population and sampling frame the 38-show sealed result is allowed to represent; cleanliness does not by itself establish representativeness.
+4. Whether Part 6 will include any broad quantitative reliability or automatic-publication claim. If not, the existing field-test record is sufficient for its narrower product story; if so, the corresponding clean evaluation or deployment record must exist first.
+5. Completion of the per-run version, availability, capture, delivery, truth, and external-observation records required by the already-frozen August 13-28 western-run policy.
+
+These open decisions do not block Parts 1-6. They bound Part 6's ending: the current version may claim that a live prototype emitted correct identities and that the development process became more auditable, but not a whole-show reliability estimate, viewer benefit, independent generalization, or successful automatic-publication path. Part 7 remains deliberately open on outcome until the August 28 cutoff and reconciliation of its complete eleven-show versioned record.
+
+---
+
+[Back to the editorial plan](/series/the-machine-in-the-lab/editorial-plan/)

--- a/_drafts/two-notebooks-lost-three-pass-audit.md
+++ b/_drafts/two-notebooks-lost-three-pass-audit.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "Two Notebooks Lost: Three-Pass Editorial Audit"
+date: 2026-08-16 03:00:00 -0400
+published: false
+---
+
+# Audit Scope
+
+This record covers `_posts/2026-08-18-two-notebooks-lost.markdown`. The structural, evidence, and rendered-readability reviews were run independently and in that order. Evidence and readability were rerun after later edits.
+
+# Pass 1: Structural Reader
+
+The opening now distinguishes the two failures chronologically instead of collapsing them into one deletion event. The SetScope origin and Phish detour precede the notebook accounts. Notebook 1 owns the information-boundary failure; Notebook 2 owns the measurement failure. The archive-versus-delete incident was moved beside the discussion of plausible agent substitutions, and the ending hands the information question to Part 3.
+
+**Result:** Pass after revision.
+
+# Pass 2: Evidence Reviewer
+
+The repository history corrected the draft's timeline to April 30 and May 6. The Notebook 1 mechanism is now pair-level performance reuse, not provider-copy duplication. The ninety-second rule, four duration calculations, seven axes, nine affected scripts, two articles, and eventual hard deletion are supported. Opening-composition lengths are explicitly presented as the author's listening notes. The first discipline document is correctly described as 273 lines, with ten rules, four roles, and seven workflow steps.
+
+**Result:** Pass after correction and recheck.
+
+# Pass 3: Readability Editor
+
+The rendered read found that the deletion substitution and the 273-line process document delayed the central turn. The deletion incident remains complete; the process-document example is now compressed to its argumentative role. The final rendered reread found no remaining flow or mobile-layout defect.
+
+**Result:** Pass.

--- a/_drafts/what-happened-on-the-august-run-three-pass-audit.md
+++ b/_drafts/what-happened-on-the-august-run-three-pass-audit.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "What Happened on the August Run: Three-Pass Editorial Audit"
+date: 2026-08-16 03:05:00 -0400
+published: false
+---
+
+# Audit Scope
+
+This record covers the unscheduled scaffold `_drafts/what-happened-on-the-august-run.markdown`. It is not a publication-ready verdict. The structural, evidence, and rendered-readability reviews cover the completed framing, August 13 baseline, frozen policy, and placeholders. Every tour-result section must be reviewed again after reconciliation.
+
+# Pass 1: Structural Reader
+
+SetScope is defined before terms such as blind or metric-eligible. The August 13 baseline now precedes the ledger and motivates the collection policy. The deployed-version record contains only the confirmed 0521 assignment; later controller candidates are explicitly engineering lineage. Every result placeholder remains in place.
+
+**Result:** Pass as a provisional scaffold.
+
+# Pass 2: Evidence Reviewer
+
+The draft now speaks from the frozen 2026-08-15 17:41:22 UTC ledger snapshot and does not infer non-occurrence from pending rows. August 13 is the sole reconciled pilot; August 14 remains unresolved. Policy v2 and the v3 addendum are named with their freeze times. Policy requirements are not presented as implemented runtime instrumentation. The supported baseline remains ten of twelve emitted identities, eleven of twelve in the acoustic diagnostic, three false switches, two misses, and an invalid first-set timebase.
+
+**Result:** Completed claims pass; all later results remain provisional.
+
+# Pass 3: Readability Editor
+
+Repeated status language was compressed. The eleven-show ledger, one-row deployment table, and availability table overflowed or clipped on mobile, so they became wrapping lists and prose records. A final 375 px rendered read found no overflow or remaining flow defect. The draft has no publication date, remains `published: false`, and has no `_posts` copy.
+
+**Result:** Pass as an unpublished provisional draft. Rerun all three gates after results prose is written.

--- a/_drafts/what-happened-on-the-august-run.markdown
+++ b/_drafts/what-happened-on-the-august-run.markdown
@@ -1,0 +1,141 @@
+---
+layout: post
+title: "What Happened on the August Run"
+subtitle: "A live product is a history of versions, misses, and repairs, not one score."
+published: false
+group: ai
+series: lab
+editorial_review: three-pass
+permalink: /series/the-machine-in-the-lab/what-happened-on-tour/
+categories: ai research zabriskie agents
+---
+
+> **Draft status, August 15:** As of the frozen ledger snapshot at 2026-08-15 17:41:22 UTC, only the August 13 pilot has a reconciled result. Every remaining result is marked below rather than inferred or invented. This note will be removed after the August 28 cutoff and final reconciliation.
+
+SetScope listens to a live Goose stream and displays its best guess about the current song without receiving the show date or setlist. On August 13, it produced correct identities from a genuinely new show while Goose was still onstage. Only part of the capture remained valid, so the run did not produce a metric-eligible whole-show result.
+
+## What the tool promised
+
+The practical goal is to let someone watching the stream see what is playing without consulting an external setlist.
+
+The product has at least four observable layers. The acoustic models emit candidates. A controller enters or changes a stable song lock. The interface renders that state. An optional adapter can publish the guess into chat or another outward surface. An event at one layer does not establish that the next one occurred.
+
+For this run, the question is therefore not "how accurate was the model?" It is what each instrumented version actually heard, emitted, held, displayed, or published under the conditions of each show.
+
+## The pre-policy baseline
+
+The August 13 San Diego pilot establishes the baseline from which later versions changed. The runtime emitted correct identities at least once for ten of twelve performances, made three false switches, and missed two performances. The post-show acoustic diagnostic found eleven of twelve, showing that controller state was materially worse than candidate discovery.
+
+The two misses also exposed different product limits. Capsized was a first-time-played cover outside the closed catalog. Correct 726 evidence appeared during the encore, but the controller retained an already incorrect state. Set 1 then failed its capture-timebase check, preventing exact latency measurement for that portion of the show.
+
+These observations motivated unknown handling, controller work, and stronger capture accounting. They remain pre-policy history and do not enter the August 15-28 aggregate.
+
+The frozen ledger covers eleven Goose performances from August 13 through August 28:
+
+- **August 13, Cal Coast Credit Union Amphitheater:** pre-policy pilot; partially valid shadow run; descriptive only.
+- **August 14, Greek Theatre:** pre-policy ledger row; reconciliation pending; excluded from the post-policy aggregate.
+- **August 15, Frost Amphitheater:** post-policy; pending.
+- **August 16, Grand Theatre at Grand Sierra Resort:** post-policy; pending.
+- **August 18, Commodore Ballroom:** post-policy; pending.
+- **August 19, WAMU Theater:** post-policy; pending.
+- **August 21, Hayden Homes Amphitheater:** post-policy; pending.
+- **August 22, Hayden Homes Amphitheater:** post-policy; pending.
+- **August 24, Kettlehouse Amphitheater:** post-policy; pending.
+- **August 27, Red Rocks Amphitheatre:** post-policy; pending.
+- **August 28, Red Rocks Amphitheatre:** post-policy; pending.
+
+As of the 2026-08-15 17:41:22 UTC snapshot, only August 13 has a reconciled source record. It used model version 0521 in blind shadow mode, contains one invalid and one valid capture session, lacks a preserved UI-observation receipt, and did not exercise publication. The August 14 row remains deliberately incomplete rather than reconstructed from memory. No reconciled result appears in that snapshot for the remaining rows.
+
+The source system also labels thirteen earlier June and July performances as Summer Tour 2026. They are outside this retrospective. SetScope live testing began in August, and expanding the denominator backward would create a tour claim about shows the product never attempted to hear.
+
+## The record we kept
+
+Each scheduled show receives a row even when no usable result exists. The ledger records whether a stream was available, whether an attempt began, which candidate and policy ran, whether capture remained valid, and which artifacts survive.
+
+For a session to be metric-eligible, the frozen policy requires preserved music-gate changes, candidate emissions, stable lock entries and clears, UI observations, and any publication attempt, acknowledgment, visible receipt, correction, failure, or duplicate. It also requires source frames, finalized audio, and recognizer-decoded samples to reconcile before the session contributes to time-based metrics. A future run still has to demonstrate that the runtime and surrounding observers produced those artifacts.
+
+Truth is created after the show from the final setlist and captured audio. For the post-policy period, the first truth artifact is assembled without access to SetScope predictions. It records plausible onset and transition intervals rather than pretending a segue has one naturally exact breakpoint. If the reconciler sees the predictions first, that truth remains useful for diagnosis but does not enter the primary post-policy metrics.
+
+This produces more missing values than reconstructing everything from memory would. That is deliberate. A lock without a UI receipt remains an internal lock. An acknowledgment without an independent fetch remains an acknowledged attempt. A show with invalid capture remains an operational failure even when some guesses look correct.
+
+## Two pilots, then a frozen collection policy
+
+August 13 and 14 occurred before the retrospective policy was frozen. The documented August 13 pilot remains in the narrative because it changed the product. August 14 remains an unreconciled ledger row and contributes no result. Neither is pooled into the August 15-28 metrics.
+
+Policy v2 was frozen at 2026-08-15 17:41:22 UTC, followed by the v3 addendum at 17:54:34 UTC, before the Stanford show. Together they fix the population, event meanings, capture tolerances, truth process, denominators, scoring derivations, and rules for version stratification. SetScope can change during the run, but a later version does not rewrite an earlier show's history.
+
+This matters because the system will almost certainly improve in response to specific failures. A controller revised after San Diego is confounded with every later song, venue, stream, and operating condition. Comparing its percentage with the earlier version is useful product history, not a controlled estimate of the code change's causal effect.
+
+The deployed-version record currently contains one confirmed assignment: version 0521, the adaptive gate-window controller, ran in blind shadow mode on August 13.
+
+Later engineering candidates added a [short-budget boundary path](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0523-boundary-short-budget-fast-path-result.md), an [unknown guard for initial locks](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0530-unknown-guard-initial-lock-result.md), and [continuous recovery from unknown](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0532-continuous-unknown-recovery-result.md). Those artifacts establish engineering succession, not deployment. Until a show row names its installed artifact and policy, the retrospective cannot assign that show to the latest available candidate.
+
+The August 14 Los Angeles pilot still requires reconciliation. Until the record establishes whether a run occurred, which version ran, whether capture was valid, and what artifacts survive, it contributes no recognition result.
+
+## Availability before accuracy
+
+The first August-run report describes operation, not recognition:
+
+- **Pre-policy pilots, two scheduled:** one stream and one attempt confirmed; the other remains pending. No fully valid run is confirmed. One partially valid run is confirmed. Publication was not exercised in the confirmed run.
+- **Post-policy collection, nine scheduled:** stream, attempt, validity, and publication states remain pending in the frozen snapshot.
+
+After August 28, every pending cell will be replaced from the ledger. A stream that is unavailable is not a classifier miss; it is an availability limit outside SetScope's control that still prevents the viewer-facing service from operating. An operator who cannot start the tool records a failure of this deployment workflow, not automatically a defect in the classifier or application code. Capture failures and incomplete logs have their own states. None may be converted into a recognition result.
+
+A partially valid show remains partially valid even if one set supplies usable song opportunities. The valid opportunities may contribute to version-specific identity results when their entire interval falls inside a session declared valid before truth is inspected. They do not convert the show into a successful run.
+
+## How often and how quickly it was correct
+
+The identity results will report counts before percentages:
+
+**[RESULTS PENDING: For August 15-28, insert metric-eligible in-catalog song opportunities; first stable locks emitted; correct first locks; correct locks by 60 and 90 admitted music seconds; opportunities with no correct lock; and out-of-vocabulary episodes assigned a catalog identity. Stratify every result by exact product version.]**
+
+Latency begins at an interval, not an exact point, when a song segues from the previous performance. The primary clock is admitted music time, with captured time reported separately. A song that never locks remains censored in the denominator rather than receiving the slowest observed latency.
+
+**[RESULTS PENDING: Report median and distribution of time to first correct candidate and first correct stable lock, including onset uncertainty. Compare with external setlist observations only for songs where both observer receipts exist and host clocks are healthy.]**
+
+An external comparison measures when Zabriskie's observer first received a matching external setlist value. It does not reveal when an external editor recognized the song or when another fan first saw it. The event definitions have to match before a timing difference means anything.
+
+## The failures the aggregate would hide
+
+Every miss receives a mechanism category before examples become a story:
+
+- capture or timebase invalidity;
+- music-gate admission during nonmusic or rejection during music;
+- no correct acoustic candidate;
+- correct candidate blocked by the controller;
+- false switch inside a continuing performance;
+- delayed or ambiguous segue handling;
+- out-of-vocabulary or debut material;
+- missing catalog or alias coverage;
+- UI state without an observation receipt; or
+- attempted publication without confirmed delivery.
+
+**[RESULTS PENDING: Insert failure counts by category and version. Retain unresolved cases as unresolved rather than assigning the most flattering subsystem.]**
+
+This is also where the songs that seemed as though they should be easy return to the story. Thatch and Big Modern have distinctive openings to a listener familiar with Goose. In San Diego, their opening evidence arrived near the earliest point the architecture could produce it, but the later state behavior was poor. That suggests at least two questions: whether a short-window opening model reduces first-lock latency, and whether the continuous controller can avoid treating later jam sections as new songs.
+
+**[RESULTS PENDING: After complete denominators are visible, compare Thatch, Big Modern, and other repeated opportunities across versions. Use them to explain mechanisms, not to replace the aggregate.]**
+
+## What reached the screen and chat
+
+The live console makes the internal process visible, but a persisted lock does not prove that a viewer saw it. The policy counts a UI-observed event only when the rendered state is polled or observed with the same identity and timestamp. Whether each post-policy run supplies that receipt remains part of the result.
+
+Publication has still more required states. A conforming record distinguishes an attempted post, its acknowledgment and durable identifier, and an independent fetch establishing visibility. Corrections and duplicates are separate events. Shadow-mode guesses never count as delivered posts.
+
+**[RESULTS PENDING: Report UI-observed locks, publication attempts, acknowledgments, independently visible posts, failures, corrections, and duplicates by run. If publication is never exercised, say so plainly.]**
+
+Whether the display helped anyone is a different question. I can report my own experience and attributed comments from people who used it. The telemetry can show that a correct title appeared before an external observation. It cannot show that a viewer noticed, trusted, or benefited from the title without direct evidence from the viewer.
+
+## What the August run changed
+
+**[RESULTS PENDING: Write the product verdict after the August 28 cutoff, manifest reconciliation, blind truth freeze, and deterministic scoring report. State which version-specific changes remain, which regressions appeared, and which open questions move into the next run.]**
+
+There are several honest endings available.
+
+The product may become accurate when it operates but remain unreliable to start and capture. It may recognize openings quickly and still switch incorrectly during jams. It may become conservative enough to preserve precision while abstaining too often to be useful. It may fail to improve. The run may also be operationally compromised enough that no broad recognition summary is eligible.
+
+All of those outcomes are publishable because the purpose of the ledger is to preserve what happened, not to manufacture the launch story we hoped to tell.
+
+The project began with a simple wish: let a computer listen to a Goose show and tell me the song. The difficult part turned out not to be producing a plausible title. It was building a loop that could keep a plausible title, a correct title, a stable displayed title, and a defensible claim about the product from collapsing into the same thing.
+
+On August 28, the record will decide how far we got.

--- a/_drafts/when-every-check-passes-three-pass-audit.md
+++ b/_drafts/when-every-check-passes-three-pass-audit.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "When Every Check Passes: Three-Pass Editorial Audit"
+date: 2026-08-16 03:02:00 -0400
+published: false
+---
+
+# Audit Scope
+
+This record covers `_posts/2026-08-24-when-every-check-passes.markdown`. The structural, evidence, and rendered-readability reviews were run independently and in that order. Evidence and readability were rerun after later edits.
+
+# Pass 1: Structural Reader
+
+The opening now explains that the approval machinery existed because the earlier notebooks had failed. Internal `Q23` shorthand was removed. The corrected case account is stated once, followed by the distinct methodological point that an erratum also needs an outside evidence path. The ending hands deployed-path validity to Part 5.
+
+**Result:** Pass after revision.
+
+# Pass 2: Evidence Reviewer
+
+May 23 publication, five advisor conditions, three artifact audits, the published six-of-eight result, all ten timestamps, and the case-level table are supported. The preserved contradiction is handled explicitly: the case record supports eight composed returns, one track-end interpretation, and one rejected mark, while the old prose incorrectly says nine of ten. Seven broader-set hits and their 36-to-127-second boundary distances remain bounded by a single-rater, outcome-aware review.
+
+**Result:** Pass.
+
+# Pass 3: Readability Editor
+
+The contradiction paragraph was split, the listening review was named directly, and the later assignment redesign was separated from the limitations of the first review. The four-column case table overflowed the article on a 375 px viewport, so it became a stacked case list. The final rendered reread found no overflow or remaining flow defect.
+
+**Result:** Pass.

--- a/_includes/series-prev-next.html
+++ b/_includes/series-prev-next.html
@@ -64,7 +64,7 @@
           <span class="series-prev-next-card series-next series-prev-next-pending">
             <span class="series-prev-next-direction">Next →</span>
             <span class="series-prev-next-title">{{ next.title }}</span>
-            <span class="series-prev-next-date">{% if next.date %}publishes {{ next.date | date: "%B %-d" }}{% elsif next.status == "draft" %}draft in progress{% else %}in development{% endif %}</span>
+            <span class="series-prev-next-date">{% if next.status == "collecting-results" %}collecting tour results{% elsif next.status == "blocked-on-result" %}blocked on evidence{% elsif next.date %}publishes {{ next.date | date: "%B %-d" }}{% elsif next.status == "draft" %}draft in progress{% else %}in development{% endif %}</span>
           </span>
         {%- endif -%}
       {%- else -%}

--- a/_posts/2026-08-18-two-notebooks-lost.markdown
+++ b/_posts/2026-08-18-two-notebooks-lost.markdown
@@ -1,0 +1,112 @@
+---
+layout: post
+title: "Two Notebooks Lost"
+subtitle: "The code was mostly right. The experiments were already lost."
+date: 2026-08-18 08:00:00 -0400
+group: ai
+series: lab
+editorial_review: three-pass
+permalink: /series/the-machine-in-the-lab/two-notebooks-lost-series/
+categories: ai research zabriskie agents
+---
+
+I deleted two notebooks of audio research during this project, but not at once. Notebook 1 failed after four days on April 30. I wrote down what had gone wrong and started over that day. Notebook 2 failed for a different reason on May 6, less than a week later.
+
+Between them, the notebooks represented a little more than a week of nearly continuous agent work. The second had already produced two long articles and a listening study I had asked friends to complete in their free time. The study was already in front of two people. One of them, my regular Phish-going friend Patrick, had spent an evening on it. I was planning to talk about the results at a music festival beginning two days later.
+
+All of it came down because each notebook contained a silent setup decision that invalidated what followed. The decisions were different. One crossed an information boundary. The other changed what the experiment was measuring. In both cases, most of the code worked exactly as written.
+
+This is a postmortem about what an LLM agent did, but it is not an attempt to assign the mistake to the machine and walk away clean. I asked the agent to move quickly. I accepted its framing of the work. I read the charts and the prose and did not trace the setup all the way back to the data. The project moved faster because of the agent, and the failures traveled at the same speed.
+
+I have a PhD and have spent much of my career doing systems research. That background helped me recognize the failures once they were visible. It did not stop me from accepting their premises while they were hidden inside a large volume of competent-looking work.
+
+## The project before the notebooks
+
+The original idea was not to study improvisation. It was to build an automatic setlist tool for [Zabriskie](https://zabriskie.app).
+
+Goose streams many of its shows live. A viewer can usually learn what song is playing by waiting for someone to update a setlist, checking a fan site, or recognizing it. I wanted the computer to listen to the stream and say, in real time, what the band was playing. I had a growing archive of labeled shows from Bandcamp and public archives. Track boundaries and titles supplied a large, imperfect, but unusually useful supervised corpus.
+
+The first practical question was direct: given thirty or sixty seconds of an in-progress performance, can a system identify the song without knowing the date or consulting the setlist?
+
+Then the corpus started suggesting more ambitious questions. Jam-band performances contain repeated compositions, long improvisations, segues, returns to earlier themes, and community labels for musical events whose boundaries are sometimes disputed even by careful listeners. The apparent power of the audio features made it tempting to ask whether those events could be measured too. The setlist project became a broader audio-research program. I started working with Phish because its archives and community annotations made the harder questions look unusually tractable.
+
+This detour mattered. Automatic song identification asks whether a predicted title matches the song that is actually playing. The jam questions asked where improvisation begins, where it ends, and what an audible return to composed material means. The first problem is difficult engineering. The second also contains a measurement problem.
+
+## Notebook 1
+
+The first notebook evaluated pairs of performances using cross-validation. The held-out rows were supposed to remain untouched until the end of the analysis.
+
+The agent built a per-performance feature pipeline, trained a classifier, and produced early evaluation results. The numbers were good. They were good enough that I became suspicious and asked for an audit of the split.
+
+The pair rows did not overlap, but the performances inside them did. Performance A could appear in a training pair `(A, B)` and then appear again in a held-out pair `(A, C)`. The model was being evaluated on individual performances it had already encountered through other pairs.
+
+Once I knew that, there was no honest adjustment to the reported number. The leak had influenced the feature work, model choices, and interpretation of early results. Making a cleaner split after seeing those outcomes would produce a useful engineering experiment, but it would not restore the independence the original test was supposed to provide.
+
+I withdrew Notebook 1 after four days, wrote a short list of things not to do again, and started over. Its files remained in the working tree until May 4.
+
+The lesson I should have written was larger: a split I did not personally inspect was not a split I had established.
+
+## Notebook 2
+
+Notebook 2 looked much more disciplined.
+
+I created a new corpus and wrote a methodology framework organized around four research questions. The first question was about "operationalization knobs," the decisions required to turn an informal musical idea into something a program can compute. The document explicitly warned against defining a performance as a ninety-second composed head, a ninety-second composed tail, and a jam in between. That fixed-offset rule fails whenever the opening composition lasts longer than ninety seconds, which is true for most of the songs I wanted to study.
+
+I gave the framework to the agent. We built seven audio axes, per-performance fingerprints, per-window heat maps, clustering analyses, threshold sweeps, and canary checks. The work produced patterns. The patterns produced two articles, complete with timestamped walkthroughs and guided listening. I built a small site for the research and a listening assignment so other people could check whether the metrics corresponded to what they heard.
+
+For six days, the work looked like work.
+
+Then a reviewer raised an asymmetry in two of the axes. I asked the agent to explain what the script was doing. During that explanation, it mentioned two constants named `HEAD_S` and `TAIL_S`. Both were set to ninety seconds. The implementation treated every window after the first ninety seconds and before the last ninety seconds as jam material.
+
+The constant came from an earlier audit script. It had been reused in the new pipeline without being reconsidered, even though the written framework identified that exact reuse as a failure mode.
+
+I asked what this did to specific tracks. The rule always assigned the track duration minus the first and last ninety seconds to `jam`. Using the rounded durations below, that works out to roughly 84, 79, 90, and 84 percent of each track. The answer was not subtle:
+
+- A June 29, 2000 Sand was 18.8 minutes long. In my listening notes, the opening composition ran roughly four to five minutes.
+- A September 4, 2016 Light was 14.1 minutes long. I heard roughly three to four minutes of opening composition.
+- A 1994 Bangor Tweezer was 29.9 minutes long. I put its opening composition at roughly three to five minutes.
+- A 2024 Bethel Bathtub Gin was 18.4 minutes long. I heard roughly five to seven minutes of opening composition.
+
+In every case, the script began the jam at ninety seconds.
+
+Several minutes of verses, choruses, and composed instrumental material had been placed inside the windows labeled `jam`. Every chart built from those windows mixed the musical phenomenon I wanted to study with material the method itself said should be excluded.
+
+The default propagated through nine analysis scripts and the artifacts they produced: fingerprints, threshold sweeps, cluster assignments, silhouette scores, confidence intervals, per-window data, and every cell in the article figures. Research questions 2 through 4 lost their numerical findings; the first question was principally a preregistration. The listening study was asking people to evaluate evidence the project itself could no longer defend.
+
+So Notebook 2 came down too.
+
+## Why the code review did not save me
+
+Neither notebook failed because the generated Python was nonsense. Imports resolved. Types lined up. Feature arrays had the expected dimensions. Charts read the artifacts they were supposed to read. The prose accurately described the chart values.
+
+In Notebook 1, a few lines created the wrong unit of separation. In Notebook 2, one inherited number defined the wrong observation window. The surrounding implementation was mostly correct. Reviewing the diff for ordinary software quality would not necessarily have exposed either decision.
+
+Research software has an awkward property: setup is part of the claim. A window size, grouping key, exclusion, normalization reference, or threshold can be a few characters in a program and still determine what evidence the program is capable of producing. When the decision is wrong, the program may run more cleanly than ever. It is computing the wrong experiment without complaint.
+
+The agent was good at producing plausible continuations. An earlier script had a ninety-second constant, so the next script inherited it. A request to remove public assignments could be satisfied by archiving them. A request for progress after a process failure could be satisfied by producing a process. None of these moves was absurd in isolation.
+
+After Notebook 2 failed, I told the agent to delete the active listening assignments so they would no longer appear on the site. It changed their status to `archived` and wrote a log entry explaining that this achieved my public-takedown intent while avoiding a destructive action. I had said delete. The agent had made a locally defensible substitution and presented it as the completed task. I had to ask again, using the phrase "hard delete," before the rows were removed.
+
+This did not ruin an experiment. It revealed the same interaction in miniature: the agent filled an unstated decision with a reasonable default, and the result looked responsible while doing something I had not authorized.
+
+A little later, frustrated with cleanup, I asked for some real progress that was not tainted. The agent responded with a 273-line research-discipline document: ten rules, four roles, and a seven-step approval workflow. We still use descendants of it, but at that moment it was a process artifact in response to a request for an empirical result.
+
+The silence was the problem. The downstream work treated each choice as settled before I knew a choice had been made.
+
+By the time a result exists, it becomes harder to inspect its premises without wanting the premises to be right. I had charts. I had interpretations. I had articles that felt like articles I would respect if someone else wrote them. The quantity and polish of the artifacts increased the cost of asking whether the first step had been valid.
+
+I did not ask early enough. The agent did not volunteer the decision. That is the system we actually built.
+
+## Two failures, not one
+
+It would be convenient to end this by writing a checklist called "never trust defaults." That would miss the important distinction between the notebooks.
+
+Notebook 1 failed because information crossed a boundary. The test evidence was no longer independent of training and development. This is a provenance problem that extends through duplicate files, derived caches, feature choices, and the researcher who remembers what happened.
+
+Notebook 2 failed because an implementation convenience defined the observable phenomenon. Even with a perfectly isolated test set, the pipeline would still have called several minutes of composition a jam. This is a meaning problem. It asks whether the measurement corresponds to the event named in the claim. A later experiment would pass every process gate we wrote after these failures and demonstrate that the problem was not solved by cleaner procedure.
+
+The common mechanism is acceleration. The agent could propose code, implement it, run it, interpret the output, write the article, and suggest the next experiment before I had fully inspected the premises of the first one. Every trip around the loop made the hidden choice more expensive to surface.
+
+We eventually returned to the original set-detection problem. That return did not make the two lost notebooks irrelevant. It gave us a narrower question with an answer that could be checked during a live show. It also forced us to decide what a check actually is.
+
+The first answer begins with the boundary Notebook 1 crossed: once evidence helps shape the system, what would it mean for that evidence to be independent again?

--- a/_posts/2026-08-21-the-holdout-is-a-one-way-door.markdown
+++ b/_posts/2026-08-21-the-holdout-is-a-one-way-door.markdown
@@ -1,0 +1,111 @@
+---
+layout: post
+title: "The Holdout Is a One-Way Door"
+subtitle: "Evidence cannot independently confirm the claim it helped shape."
+date: 2026-08-21 08:00:00 -0400
+group: ai
+series: lab
+editorial_review: three-pass
+permalink: /series/the-machine-in-the-lab/the-holdout-is-a-one-way-door/
+categories: ai research zabriskie agents
+---
+
+The first cross-validation scheme in the audio project looked clean at the row level and failed inside each row.
+
+Each row contained a pair of performances, and the pair rows did not overlap. But an individual performance could appear in more than one pair. Performance A could be part of training pair `(A, B)` and then return inside held-out pair `(A, C)`.
+
+This is the useful way to think about a holdout: it is not a folder, dataframe column, or call to `train_test_split`. It is a promise about unavailable information.
+
+The promise says that the evidence used for final evaluation did not help choose the model, features, thresholds, exclusions, aliases, or story being evaluated. If the evidence shaped those decisions, moving its files to a new directory does not make it independent again.
+
+## The unit that has to stay apart
+
+Live audio makes the obvious version of this problem unusually easy to create.
+
+One Goose show may exist as a Bandcamp FLAC, an Archive.org recording, a stream capture, an MP3 conversion, and a set of tracks cut at slightly different boundaries. Two recordings may come from the same source with different metadata. One may include thirty seconds of crowd noise that another omits. Hashes can differ even when much of the underlying performance is the same.
+
+If I split at the file level, the model can train on one copy of a performance and test on another. If I split at the track level, songs from the same show can still cross the boundary and carry venue, mix, crowd, tuning, and recording-source signatures with them. A classifier that appears to recognize a song may partly be recognizing a particular night.
+
+The relevant unit therefore depends on the claim. For the early classifier, at minimum, all representations of a performance had to stay together. For stronger generalization claims, whole shows or chronological blocks had to stay together. Duplicate detection had to operate on more than filenames and exact bytes.
+
+None of this is exotic machine learning. The problem is that an agent can build a formally valid split at the wrong unit, then generate enough downstream work that the unit disappears from attention.
+
+## The cache remembers too
+
+For Notebook 1, the rule is straightforward: derived artifacts inherit the data role of their sources.
+
+If test audio contributes to a normalized feature, the normalization artifact has seen the test set. If a threshold is chosen from a sweep containing test outcomes, the threshold has seen the test set. If a candidate list is ranked using held-out performance, the ordering has seen the test set. A cache does not become neutral because it stores numbers instead of audio.
+
+After the two notebook failures, the project removed 1,120 derived artifacts: 51 jam-only chroma arrays, 153 jam-feature variants, 320 sliding-window variants, 325 per-track JSON summaries, and 271 other feature files.
+
+That number is real, but it needs care. The [surviving audit](https://github.com/cmeiklejohn/zabriskie-audio-research/blob/bfd8b0aa360b7898d7f50fa4aa6f119a9783d4d5/docs/logs/r7-errata-2026-05-17-cache-contamination.html) describes a mixed purge of descendants from both notebooks. It does not cleanly assign every one of the 1,120 files to a single failure lineage.
+
+Notebook 1 descendants carried information contamination where their values were derived from the leaked split. Notebook 2 descendants embodied a measurement premise that had become invalid. They were removed together because both sets were unfit for the work that was about to reuse them, not because both failures were the same kind of leakage.
+
+This became uncomfortable when we examined integrity checks that had passed. One check compared a pinned value in a manifest with a value re-derived from a cached baseline. The values matched, which looked like independent confirmation. They matched because both descended from the same contaminated computation.
+
+The check proved consistency. It did not prove independence.
+
+This distinction is easy to lose in agent-generated work because the system can produce a hash, a manifest, a recomputation script, and a green report around one lineage of evidence. The artifact chain becomes more traceable without becoming less circular.
+
+## The human crosses the boundary
+
+The harder leak is not in a file.
+
+Suppose I evaluate a model on a holdout and learn that So Ready is often confused with Arrow. I inspect both classes, add a rhythmic feature, change a threshold, and run the holdout again. Perhaps the second result improves. The holdout labels never entered gradient descent. They still changed the system.
+
+The same thing happens when I:
+
+- add or remove a feature family after seeing which songs fail;
+- alter aliases after inspecting errors;
+- exclude unusually short tracks after they reduce a metric;
+- change the music gate after seeing preshow failures;
+- tune a confidence threshold against the desired headline;
+- choose the next hypothesis because a result made it seem promising; or
+- stop iterating when the number finally looks acceptable.
+
+The researcher is part of the information path. So is the agent, if it reads the evaluation report and proposes the next candidate.
+
+This is why leakage and HARKing, hypothesizing after the results are known, meet in an iterative system. A hypothesis developed after seeing an outcome may be interesting and worth testing. It is exploration. The same outcome cannot then be presented as independent confirmation of the hypothesis it caused us to formulate.
+
+The problem is not that people learn. Research depends on learning from results. The problem is representing adapted evidence as if the adaptation did not happen.
+
+## A one-way door for a particular claim
+
+Opening a holdout does not poison the audio forever.
+
+This point matters because the strong version of the rule quickly becomes absurd. If I listen to a 2024 Goose show while debugging a song recognizer, the recording can still be useful for studying an unrelated question about crowd-noise removal. It can remain training data, engineering data, a regression fixture, or an example in a user interface. Data does not acquire a universal contamination mark because a human saw it.
+
+The permanent status is scoped to the claim, candidate, and adaptive lineage the outcome influenced.
+
+If I inspect the 2024 show to tune recognizer thresholds, it cannot later serve as sealed confirmation of that recognizer or a descendant that inherited the tuning decision. A new Git branch does not change this. Neither does deleting the result, forgetting the exact score, or asking a different agent to rerun the script. The information has entered the development history.
+
+A genuinely unrelated question can reuse the raw recording when its measurement, candidate, thresholds, exclusions, and analysis policy do not inherit choices from that opened result. Ambiguous cases should be treated as opened engineering work and recorded that way. That policy gives up some rhetorical convenience in exchange for an honest account of what the evidence can support.
+
+## What the current boundary looks like
+
+The rebuilt recognizer uses several overlapping controls because no single file split can carry the promise:
+
+1. Audio is grouped by performance and show before assignment.
+2. Exact and near-duplicate controls look across providers, encodings, and track cuts.
+3. Chronological evaluations reconstruct only information that would have existed at the prediction date.
+4. Data populations have explicit roles: training, opened engineering, prospective field test, or sealed evaluation.
+5. Plans, candidate hashes, catalog snapshots, and scoring policies are frozen before a sealed run.
+6. Labels remain opaque during prediction and are joined only during scoring.
+7. Opening an evaluation creates a permanent record of which candidate and policy saw it.
+
+These rules are not proof that a result is clean. They make the promise inspectable. A future reader can determine which shows were available, how the grouping worked, what version ran, when labels became visible, and whether the result was used to change the next candidate.
+
+This also explains why small personal projects find clean evaluation expensive. Every show held back is a show unavailable for diagnosis. Every opened result reduces the supply of evidence that can independently answer the same question. A researcher with a finite corpus cannot keep creating fresh test sets after each disappointing result.
+
+The practical answer is role separation, not amnesia. Use opened shows aggressively for debugging. Preserve a smaller sealed population for one frozen candidate. Accumulate prospective evidence by running future shows, while recognizing that each show becomes opened for every later version once its outcome has influenced development.
+
+## What a clean holdout does not establish
+
+It is possible to do all of this correctly and still be wrong.
+
+A whole-show split can prevent the model from hearing the same performance twice. Frozen hashes can prove that the candidate did not change. Opaque labels can show that the scorer did not inform prediction. None of those checks establishes that the feature, label, or detector means what the claim says it means.
+
+Notebook 2 had this different failure. Its ninety-second segmentation rule could have been applied to a perfectly isolated holdout and would still have called several minutes of composition a jam. Independence would make the estimate cleaner. It would not make the measurement valid.
+
+A clean holdout still leaves a different question. What if every artifact matches the plan, but the measurement does not correspond to the event named in the claim?

--- a/_posts/2026-08-24-when-every-check-passes.markdown
+++ b/_posts/2026-08-24-when-every-check-passes.markdown
@@ -1,0 +1,122 @@
+---
+layout: post
+title: "When Every Check Passes"
+subtitle: "All the artifacts agreed. The interpretation had never been tested."
+date: 2026-08-24 08:00:00 -0400
+group: ai
+series: lab
+editorial_review: three-pass
+permalink: /series/the-machine-in-the-lab/when-every-check-passes/
+categories: ai research zabriskie agents
+---
+
+On May 23, I published an audio-research result after it passed every check the project required.
+
+Those checks existed because the two earlier notebooks had failed. We had added explicit plans, reviews, artifact audits, and publication approvals to prevent another plausible result from outrunning its evidence.
+
+The plan had been reviewed. Five advisor conditions had been applied. The figure-generation script passed three byte-faithfulness audits. The numbers in the prose traced to saved artifacts. A content audit found no unsupported numerical claims. A second advisor review approved the complete dispatch. I approved a soft launch and then a hard launch. The page went live with a homepage card and a final [publication log](https://github.com/cmeiklejohn/zabriskie-audio-research/blob/bfd8b0aa360b7898d7f50fa4aa6f119a9783d4d5/docs/logs/dispatch-002-publication.html).
+
+Every recorded check was green.
+
+Then I read the article and listened to the first example.
+
+The listener mark sat two seconds before the audible end of the song.
+
+## The result we thought we had
+
+The experiment concerned the end of a jam. In the project's labeling system, a listener marked the point where improvisation ended and the band returned to composed material. We compared those marks against an onset-density changepoint detector, a signal-processing method intended to find a large change in musical activity.
+
+The reported result was that the detector recovered the listener-marked end on three of four Sands and three of four Bathtub Gins within a song-specific tolerance. The article interpreted this as evidence that the end of a jam was acoustically recoverable as a band-level return to composed structure, even though the beginning remained difficult to detect.
+
+That interpretation was the reason the result mattered. Agreement between timestamps by itself is not very interesting. If the detector and listener were identifying the same musical event through different paths, we had evidence that a community concept could be grounded in an acoustic change.
+
+The first example was Sand from July 3, 2000. The listener mark was 11:56, the detector prediction was 11:42, and the music ended around 11:58. The archived track continued through audience and tail audio until 13:23. When I played the clip, the marked event did not initially sound like an abstract structural boundary. It sounded inseparable from the song ending.
+
+The pipeline had answered the scoring question correctly: the predicted time was near the labeled time. I no longer knew whether either timestamp supported the sentence we had published.
+
+## The first diagnosis
+
+The published six-of-eight verdict covered four Sands and four Bathtub Gins. The broader ten-case positive set also contained a Reba and a Tweezer. Five of the six reported hits had a listener mark within two minutes of the archive track boundary. Two were within a minute.
+
+The first explanation seemed obvious. Perhaps the labels were systematically anchored to the end of the musical performance rather than the return to composition. The labeling instructions allowed two cases: mark the return to composed material, or mark track end when the jam continued through the end of the song. The analysis had silently assumed every value had the first meaning.
+
+Under that explanation, the detector might have been doing useful structural work while the labels were wrong. One failed Bathtub Gin appeared to support the inversion: the detector found a shift around 14:50, while the label sat at 16:11, almost exactly at track end.
+
+We wrote the withdrawal record around that diagnosis. The central claim was unsupported because label agreement could not establish recovery of composed structure if the labels represented a different event.
+
+Listening to all ten cases made the diagnosis mostly wrong.
+
+## The labels were better than the explanation
+
+I used a one-off page that presented each listener mark and detector prediction with audio controls. Phish often returns to the song shortly before the music ends. The proximity that had looked like evidence of bad labels was, in most cases, a property of the performance structure.
+
+The [preserved review record](https://github.com/cmeiklejohn/zabriskie-audio-research/blob/bfd8b0aa360b7898d7f50fa4aa6f119a9783d4d5/docs/logs/dispatch-002-withdrawal.html#L144-L170) contains a contradiction I missed at the time. Its ten-row case table records eight listener marks I heard as composed returns, one Bathtub Gin mark as track end without a composed return, and one Reba for which I wrote that both the listener and detector marks were wrong. The summary immediately below the table says nine of ten listener marks were composed returns. Those statements cannot both be true.
+
+The table is the case-level record, so I am using eight here and treating the old nine-of-ten summary as an error. The cases were:
+
+- **Sand, July 3, 2000:** composed return; original score: hit; 1:27 to the archive boundary.
+- **Sand, December 31, 2010:** composed return; original score: hit; 0:36 to the archive boundary.
+- **Sand, July 28, 2017:** composed return; original score: hit; 1:26 to the archive boundary.
+- **Sand, October 26, 2018:** composed return; original score: miss; 2:11 to the archive boundary.
+- **Bathtub Gin, July 10, 1999:** track end; original score: miss; 0:05 to the archive boundary.
+- **Bathtub Gin, July 20, 1998:** composed return; original score: hit; 0:58 to the archive boundary.
+- **Bathtub Gin, February 14, 2003:** composed return; original score: hit; 2:06 to the archive boundary.
+- **Bathtub Gin, February 28, 2003:** composed return; original score: hit; 1:45 to the archive boundary.
+- **Reba, August 16, 1993:** listener and detector marks both rejected; original score: miss; 5:59 to the archive boundary.
+- **Tweezer, November 2, 1994:** composed return; original score: hit; 2:07 to the archive boundary.
+
+Eight of ten is enough to reject the first diagnosis that the labels were systematically anchored to track end. One label used the second permitted interpretation. One label did not survive the review at all. Most of the suspicious proximity came from the way these performances returned to the song and then ended.
+
+## What the corrected case record could say
+
+My ten-case listening review has important limitations. I was one listener. I knew the experiment had failed, knew the suspicious pattern, and saw the selected positive cases. This was an outcome-aware, post-publication review, not blinded annotation or an inter-rater agreement study. Because I reviewed selected positives, the exercise cannot estimate false negatives, specificity, or the detector's behavior over the full corpus.
+
+The review could reject our first explanation, but it did not establish the strong replacement explanation written into the withdrawal summary. All seven hits in the broader table were composed-return cases whose marks occurred 36 to 127 seconds before the archive boundary. The valid Sand miss occurred at 2 minutes 11 seconds, only four seconds beyond the largest hit gap. The Gin miss used the track-end interpretation, and the Reba mark at 5 minutes 59 seconds had itself been rejected.
+
+The algorithm selected the final large changepoint in time order, so it was structurally biased toward late events. The selected ten-case review does not show how often that bias caused a hit or miss. It showed that the original interpretation had not been independently established, and that the first confident explanation of the failure had outrun the evidence too.
+
+That is not a new detector result. It is a limit on what the old result can claim.
+
+## What the gates actually checked
+
+Nothing in the approval chain was fake. Each check answered a legitimate question:
+
+- Did the implementation follow the plan?
+- Did the generated figure match the saved numerical artifact?
+- Did the prose accurately report the figure and result?
+- Were the planned unit, thresholds, and qualifiers preserved?
+- Were the required reviews and approvals recorded?
+
+These are necessary checks. Without them, a claim can drift between plan, code, result, and prose. But every gate followed the same derivative chain. The label fed the scorer. The scorer fed the artifact. The artifact fed the figure. The figure fed the prose. Reviewers traced the claim backward through that chain and found it internally consistent.
+
+No gate asked what was audible at the labeled and predicted timestamps.
+
+Traceability established where the claim came from. It did not establish that the source measurement represented the musical event the claim named.
+
+Notebook 2 had left this debt behind. Its ninety-second default made a convenient segment define what counted as a jam. The new discipline caught inherited constants and forced plans to state their assumptions, but we treated the labels in Dispatch 002 as settled ground truth. The interpretive choice moved from a constant into the meaning of a field, where the existing rules did not know to look.
+
+The most embarrassing part was that the ambiguity was documented. The labeling instructions explicitly said `jam_end` could mean return to composition or track end if no return occurred. A plan-to-data audit could have noticed that the hypothesis assumed only the first case. It did not.
+
+## A different evidence path
+
+The project added a rule requiring an acoustic reality check for claims about audio. Before an analysis proceeds, and again before publication, someone must listen at the relevant labels and predictions and record what is audible.
+
+The value of this check is not that human hearing is infallible. It is that the evidence does not descend from the same artifact chain. A waveform feature, a label, and a chart can agree because they share an assumption. Listening can contradict the interpretation through another modality.
+
+The original reality check was not independent in every sense. I was the author, knew the outcomes, and had already proposed an explanation.
+
+Later assignments were redesigned to present neutral metadata, randomize order, omit preloaded notes, and collect structured responses. That reduces some forms of priming and makes disagreement easier to inspect. It does not turn listeners into objective instruments, and it does not retroactively improve the first review.
+
+This matters because "add a human" is not a methodology. Which human? What did they know? Which cases did they hear? What categories were available? Were disagreements preserved? A domain check has its own measurement design.
+
+The first check still did something the elaborate agent process had failed to do: it returned to the underlying phenomenon. It made the published interpretation suspect, and then it made the first attempted correction suspect too.
+
+## The erratum needs evidence
+
+An erratum can repeat the original failure if it is allowed to close around the first plausible explanation. The correction needed an evidence path outside the artifacts and diagnosis that produced it.
+
+This is the limit of process-heavy review in a discovery loop. Multiple agents can inspect a plan, implementation, result, and article while sharing one blind spot. Adding another reviewer to the same chain increases scrutiny without necessarily creating contradiction. The evaluator has to be capable of telling the entire chain that its interpretation is wrong.
+
+For Dispatch 002, that evaluator was a person pressing play.
+
+The project eventually left the jam-classification detour and returned to the original song-identification tool. That made the output easier to name: either the screen said the song that was playing or it did not. It did not make evaluation simple. An offline score still could not say what happened between the browser and the model.

--- a/_posts/2026-08-27-the-browser-is-part-of-the-experiment.markdown
+++ b/_posts/2026-08-27-the-browser-is-part-of-the-experiment.markdown
@@ -1,0 +1,137 @@
+---
+layout: post
+title: "The Browser Is Part of the Experiment"
+subtitle: "A model score cannot tell you what the live system actually heard."
+date: 2026-08-27 08:00:00 -0400
+group: ai
+series: lab
+editorial_review: three-pass
+permalink: /series/the-machine-in-the-lab/the-browser-is-part-of-the-experiment/
+categories: ai research zabriskie agents
+---
+
+The song recognizer once identified Animal before the music started.
+
+I had opened a Goose show in the browser, started SetScope, and watched the interface warm up over crowd noise. At sixty seconds, I watched it display Animal with 99 percent confidence. The music had not begun. That observation survives in my screenshot, not in the later transport-incident record.
+
+This was especially alarming because the system was supposed to contain a music gate. Preshow chatter and crowd noise were not merely difficult examples. They were inputs on which the song classifier should not have been allowed to make a decision at all.
+
+At the time, we also had an apparently strong offline result: 46 correct predictions on 54 segmented tracks from five held-out shows, or roughly 85 percent top one. I had been using that number as evidence that we were approaching a usable live recognizer.
+
+The browser was telling me the number described something else.
+
+That Animal rehearsal established a symptom, not its cause. We had not preserved enough of that session to prove why the premusic lock occurred. A later six-minute run, in which the system failed to admit any music at all, gave us the first captured input we could inspect from browser to recognizer.
+
+## A song guesser, not a scientific instrument
+
+SetScope has a deliberately ordinary job. It listens to a Goose stream and shows a viewer its best guess about the current song. The viewer should not need the show date, a setlist, or a second fan site.
+
+The title on the screen is a product output. It is not a scientific finding about Goose. A browser rehearsal is a product test. Its logs can support a methodological claim about how we evaluated the system, but correctly naming Animal does not turn the application into a research instrument.
+
+That plain description helps clarify what the old 85 percent result actually measured. We had cut labeled audio into segments and asked the classifier to name each segment. The 54 rows were leakage-disjoint at the file, performance, and show-date levels under the frozen result. They covered only 45 of the model's 254 catalog labels, and the test began with an already decoded piece of a known music track. It was a valid but narrow component evaluation.
+
+It did not measure:
+
+- whether the browser audio reached the recognizer intact;
+- whether the system stayed quiet during preshow music, crowd noise, and set break;
+- how quickly a title appeared after music began;
+- whether the displayed title remained stable through a long jam;
+- whether the system detected a segue with no silent boundary;
+- what happened when the band played a song outside the catalog; or
+- whether a correct internal state reached the screen or a public chat.
+
+Calling 46 of 54 "live accuracy" collapsed all of those untested behaviors into one convenient percentage.
+
+## The demonstrations got stranger
+
+Animal was not an isolated miss. Browser tests produced rapidly changing song identities, long delays after all acoustic models appeared to agree, and locks authorized by a contextual rule even when the audio models favored another song. One run continued for six minutes without admitting a single second of music. The selector never ran.
+
+It was tempting to treat each outcome as a classifier error. Animal is musically distinctive. Royal is musically distinctive. Thatch and Big Modern begin with recognizable riffs. Perhaps the features were not good enough, the candidate generator was too weak, or the temporal model was holding the wrong state.
+
+Those were real issues, but they assumed that the model was hearing what I heard through the speakers.
+
+The deployed path was longer:
+
+1. Chrome decoded the Nugs stream.
+2. macOS routed the output through BlackHole while maintaining a monitor path to the speakers.
+3. A capture process read the virtual audio device.
+4. The runtime segmented the stream and resampled it.
+5. A music gate decided whether enough continuous music existed.
+6. Several acoustic model families generated candidates.
+7. A temporal controller decided whether a candidate could replace the current song.
+8. The application persisted state and rendered the interface.
+
+The offline experiment began around step six. The product began at step one.
+
+## What the browser audio contained
+
+We saved the captured audio from the six-minute failure and inspected the waveform. The [incident record](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0506-browser-capture-input-integrity-incident.md) reports exact-zero gaps about 0.105 seconds long at roughly 1.1-second intervals.
+
+The signal was loud. Segment timestamps advanced normally. The dashboard therefore reported a healthy session. But the music gate saw a discontinuous input unlike the archive recording on which it had been developed.
+
+The difference was large enough to measure directly. The incident summary reported a median music-gate output of about 0.08 across the browser run's scored windows and about 1.00 when the same Animal performance was decoded from the read-only archive file.
+
+An early suspect was the asynchronous resampler. Removing it eliminated the periodic digital-zero pattern, but nominal ten-second capture segments still contained only 7.3 to 8.9 seconds of decoded audio. A direct tone test localized the remaining loss to FFmpeg's AVFoundation input path.
+
+The timestamps had been measuring files being declared, not samples successfully transported.
+
+This is why the browser belonged in the experiment. An archive decoder could not expose a macOS capture failure. A model benchmark could not tell us that the input contained holes. The product was producing apparent model behavior from invalid audio.
+
+## Making input validity visible
+
+We replaced the FFmpeg capture path with a native CoreAudio helper. It selected the named device directly, downmixed to mono, and wrote one contiguous sample stream into the segmenter.
+
+The more important change was accounting. The session began recording three quantities independently:
+
+- source frames received from CoreAudio;
+- samples finalized into the captured audio; and
+- samples decoded by the recognizer.
+
+A session passed transport integrity only when those clocks reconciled under the fixed 0.5-second tolerance. Each segment also reported RMS, peak, exact-zero fraction, and internal dropout counts. Startup failed if the selected device produced no callbacks. A completed capture with missing recognizer samples became an invalid run rather than a mysterious model miss.
+
+On a valid replay of Animal, 246.000 source seconds became 245.930667 finalized and decoded seconds. The timebase passed. The opening crowd and intro produced no song proposal. All four acoustic views eventually ranked Animal first, and the system locked it after seventy admitted music seconds.
+
+Seventy seconds was slower than I wanted, but it was a real latency measured from audio the model had actually received.
+
+## A valid input exposed a policy failure
+
+That valid capture exposed the next problem. One music-gate observation fell below threshold during continuous Animal. The runtime immediately cleared its accumulated audio window, delaying the lock. We copied the exact captured bytes and replayed them with one policy change: an uncertain gate window waited for the next observation instead of immediately resetting state. Nothing about the input or model changed. Animal locked forty seconds earlier.
+
+Exact-byte replay let us ask whether a policy change improved behavior without accidentally changing the browser input at the same time.
+
+## One song was not enough
+
+The next diagnostic started at the beginning of Dr. Darkness and allowed the Nugs player to advance naturally into Drive.
+
+The interface refreshed candidate telemetry throughout Dr. Darkness, including brief drift toward other songs, while the publication state held the correct title. When Drive began, the acoustic sources changed before the temporal controller authorized a transition. At 410 seconds, all four sources ranked Drive first and the transition model switched the held state. This was the behavior we wanted: frequently changing evidence, conservative displayed state.
+
+The run also revealed that capture wrote 48 segments while the recognizer exited after 47. The missing tail was only 1.284 seconds, and it did not change the two song decisions when replayed. It still made the original session invalid under the fixed transport rule. Shutdown was part of the input path too.
+
+Longer tests exposed errors that no isolated track could express. A system can name every segment correctly and still perform badly if it changes songs in the middle of a jam, refuses to switch across a segue, carries state through a set break, or assigns a debut cover to the nearest known title.
+
+The evaluation surface had to expand from top one to a product record:
+
+- precision and coverage of the first stable lock;
+- time from admitted music onset to first correct evidence and stable state;
+- correct, incorrect, and abstained held-state time;
+- false stable switches and their dwell;
+- behavior during nonmusic and unknown material;
+- transition behavior across pauses and segues;
+- capture validity; and
+- separately observed UI and publication delivery.
+
+These metrics do not replace controlled corpus evaluation. They answer questions the corpus experiment never asked.
+
+## The night the narrow question worked
+
+On August 13, Goose played in San Diego. SetScope listened while the show was happening and emitted correct blind song identities from audio that had not existed when the system was built.
+
+This was the smallest prospective test we had wanted from the beginning: can the runtime emit correct blind song identities during a genuinely new show?
+
+It could.
+
+The [saved run and operator record](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0521-2026-08-13-live-show-audit.md) preserve the live trace. The later run ledger records that source date and setlist context were not used. We did not preserve one canonical pre-music receipt containing every candidate hash, audio route, mode, publication state, and start field later required by the full protocol.
+
+The runtime also missed performances and changed songs incorrectly. One set failed the capture-timebase check, and we lacked separate receipts for what reached the interface or public chat. The run did not supply a formal whole-show accuracy estimate or proof of viewer-visible delivery.
+
+The next question was how to let an autonomous research program keep improving those pieces without allowing one useful field test, one large engineering replay, or one polished percentage to become a claim it could not support.

--- a/_posts/2026-08-30-a-discovery-loop-that-can-say-no.markdown
+++ b/_posts/2026-08-30-a-discovery-loop-that-can-say-no.markdown
@@ -1,0 +1,147 @@
+---
+layout: post
+title: "A Discovery Loop That Can Say No"
+subtitle: "Bound the agent, preserve the failures, and let the evidence limit the claim."
+date: 2026-08-30 08:00:00 -0400
+group: ai
+series: lab
+editorial_review: three-pass
+permalink: /series/the-machine-in-the-lab/what-we-built-instead/
+categories: ai research zabriskie agents
+---
+
+SetScope began as a viewer-facing song guesser: listen to a live Goose stream and identify the current song without receiving the date or setlist. The audio corpus pulled the project into a harder detour about measuring improvisation. Two notebooks from that detour were deleted after hidden setup decisions invalidated them.
+
+The first research-discipline document was our response. It had ten rules, named roles, explicit approvals, and an advisor agent with authority to block work. We used it for Dispatch 002, an experiment that compared listener-marked returns to composition with an acoustic changepoint detector. Every required gate passed. The general interpretation was still unsupported.
+
+The failure was useful because it changed what I thought the system needed to control. A long prompt could tell an agent to be careful. A checklist could require it to produce more artifacts. Neither represented the state of the research strongly enough to determine which action was allowed next.
+
+The project needed a discovery loop that could say no.
+
+## The loop is the system
+
+This project used an autonomous research program to improve SetScope. The program could propose an experiment, implement it, run it, evaluate the output, and choose what to try next with limited human intervention. That is the same basic ambition behind the emerging work on automated discovery loops in science and engineering. The important unit is no longer one prompt or model response. It is the loop that carries state from one iteration into the next.
+
+That state includes more than code and results. It includes which labels have been seen, which thresholds were adjusted, which failures changed the design, what the evaluator actually measured, which runtime path was exercised, and what claim the project is now tempted to make.
+
+The lost notebooks showed that information roles and methodological decisions had to survive across iterations. Dispatch 002 showed that an internally consistent evaluator could still measure the wrong thing. The browser incident showed that a correct offline experiment did not exercise the deployed audio path. In every case, an agent could produce a locally correct next step from a globally invalid state.
+
+The correction was to move the critical state outside the model's conversational memory and make it durable.
+
+## From instructions to state
+
+An instruction such as "do not use the test set" sounds clear until the project has five copies of a performance, three feature caches, a threshold selected after an opened result, and an agent that did not participate in the original decision. The instruction has to become data the system can inspect.
+
+The current process represents at least these things explicitly:
+
+- a question and the exact claim it is capable of supporting;
+- the role of every input population;
+- a candidate model, feature set, catalog, and policy identified by hashes;
+- an analysis and scoring specification frozen before outcomes are visible;
+- the boundary between prediction, scoring, diagnosis, and promotion;
+- immutable result artifacts, including invalid and negative outcomes;
+- the evidence scope of a run, from component crop to live runtime to observed UI or publication; and
+- the actions the system is permitted to take automatically.
+
+This is less elegant than telling an agent to "follow scientific best practices." It is also inspectable. A candidate cannot quietly change after the run starts if the installed artifact has a recorded digest. A shadow event cannot become a delivered chat post if publication is disabled and receipts are required. A show used for diagnosis cannot later be described as sealed confirmation without contradicting its recorded role.
+
+The rules still depend on people honoring them. State does not eliminate discretion. It makes the exercise of discretion visible.
+
+## A bounded experiment
+
+The useful unit of autonomy became a bounded experiment rather than an open-ended request to improve the model.
+
+Before execution, the experiment records:
+
+1. the question;
+2. the allowed inputs;
+3. the candidate and every configurable policy;
+4. the metric and selection rule;
+5. the compute or iteration budget;
+6. the outcome that would falsify or stop the treatment; and
+7. the downstream action the result may authorize.
+
+Planning, execution, and scoring are separate states. The planner can inspect opened engineering evidence. The executor receives frozen inputs and does not change the candidate. The scorer joins outcomes only after immutable predictions exist. Promotion requires evidence appropriate to the claim being promoted.
+
+This last point is where many agent workflows become vague. A result may authorize one action without supporting the next. A replay on 75 opened shows can justify another browser rehearsal while remaining useless as independent confirmation. A prospective run may demonstrate correct identities on future audio without supplying the capture record needed for a whole-show latency metric. Controller, interface, and publication events require their own evidence. Each promotion crosses another boundary.
+
+## Five coordinates for evidence
+
+We eventually began classifying evidence on separate axes instead of assigning it one adjective such as "clean" or "live."
+
+**Information access.** Was the outcome unavailable when the candidate was frozen, sealed until scoring, or already opened and available for adaptation?
+
+**Temporal relation.** Was the evaluation retrospective on existing audio or prospective on a future event?
+
+**System scope.** Did it exercise an isolated model, an integrated offline replay, the live runtime through controller state, the rendered interface, or an outward publication path?
+
+**Publication action.** Was the system operating in shadow mode, attempting a post, receiving an acknowledgment, or independently observed as visible?
+
+**Metric eligibility.** Did capture, truth, timing, and protocol requirements pass for the metric being reported?
+
+These coordinates prevent one strong property from standing in for the others. The August 13 run was prospective and its audio was unavailable when the candidate was built. It exercised the live path through saved controller outputs. It did not preserve complete proof of every frozen pre-music condition, its first set failed the timebase rule, its truth boundaries were reconstructed after the show, and no separate UI-observation or outward-publication receipt survives.
+
+So it establishes a valuable fact: the system emitted correct blind song identities during a genuinely new show. It does not establish a formal whole-show accuracy rate or successful automatic publication.
+
+That sentence is more cumbersome than "the live test passed." It is also much harder for the next agent to misunderstand.
+
+## Preserving failure as an output
+
+The project originally treated failed runs as interruptions on the way to the result. That made it easy to rerun something slightly differently and report only the version that completed.
+
+Now invalidation is a terminal result. A capture with missing samples retains its events but cannot contribute to metrics requiring continuous time. A candidate that emits no lock remains in the coverage denominator. An unknown song is not silently removed because the closed catalog could not name it. A planned comparison that lacks synchronized clocks is reported as missing rather than assigned a tie.
+
+Negative experiments remain useful too. One rebuilt question searched 263 curated jamchart entries for a frozen set of descriptive terms, found none, and halted before loading audio. Preserving the halt prevented the agent from silently broadening the phrase list until something matched.
+
+A protocol that produces only impeccable refusals is not a research program. The halt matters because it keeps an unobserved change from turning a failed question into an apparently successful one.
+
+## The larger opened engineering result
+
+After the August 13 show, we used opened shows to improve the temporal controller and its handling of abstention. The [corpus protocol](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0494-corpus-scale-evaluation-preregistered.md) had identified 113 eligible, manifest-verified shows from 2021 through 2025 whose dates appeared in neither fitting nor prior evaluation. A frozen within-year hash split assigned 75 to engineering and 38 to sealed confirmation without reading song titles or outcomes.
+
+The selected controller candidate, version 0532, was designed after reviewing earlier failures, including the August 13 show and version 0531. The 75 shows were opened development material. The result explicitly classified itself as engineering evidence and disabled setlist writes. The replay did not exercise Chrome, CoreAudio, the interface, or public posting, and it was not independent confirmation.
+
+Under the frozen replay rule, the selected treatment produced 65 correct initial locks by ninety admitted music seconds and abstained on the remaining ten shows. It emitted no wrong initial locks, which yields 100 percent selective initial precision and 86.67 percent correct coverage across all 75 shows. Median admitted music time to a correct initial lock was sixty seconds. It produced no premusic locks and no initial or recovery locks on out-of-vocabulary material in that replay.
+
+The [complete replay result](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0532-continuous-unknown-recovery-result.md) also retained the observation-level accounting:
+
+| Observation class | Count |
+| --- | ---: |
+| All ten-second observations | 65,085 |
+| Scoreable in-catalog observations | 61,446 |
+| Correct state | 57,079 |
+| Incorrect state | 3,415 |
+| Unlocked | 952 |
+| Outside the scoreable population | 3,639 |
+
+That is 92.89 percent correct state across scoreable observation time. Across 733 eligible in-vocabulary archive boundaries, the system detected 632 by ninety admitted music seconds, or 86.22 percent. Different slices of the replay produce different transition rates, which is precisely why the artifact retains the raw counts and scoring scope rather than one summary percentage.
+
+The larger sample does not replace the prospective field test. It answers a different question: under a frozen replay rule on these opened shows, did this treatment meet the engineering gates required to advance? It did, and the authorized next action is another complete-product test, not a universal reliability claim.
+
+## The boundary the agent cannot cross
+
+The other 38 shows from the same eligible population remain sealed under a [one-time final-candidate protocol](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0512-sealed-confirmation-execution-protocol.md). The within-year hash assignment prevents outcome- or song-based selection and preserves the year distribution; it does not make the 38 shows representative of every venue, source, year, or song in the wider Goose archive. The candidate, model artifacts, catalog, policy, inputs, scorer, and hashes must be frozen before that population is opened. Once scored, the set becomes opened forever for that candidate lineage.
+
+This is intentionally expensive. The point of a sealed evaluation is not to create a renewable source of encouraging numbers. It is to answer one question once without allowing the answer to influence the system that produced it.
+
+Even a good sealed result would remain one level in the product record. It could establish independent performance on the frozen catalog evaluation without showing that the browser path, interface, or automatic-publication path worked. Evidence at one level may authorize the next test without establishing the levels above it. Keeping those steps separate is the central job of the control plane.
+
+## What we built instead
+
+I do not think the resulting process is a universal method for AI-assisted research. It grew around specific failures in one self-directed project, and it has costs we have not measured.
+
+The gates may consume enough attention to erase the speedup. They can become paperwork. Approvals can become ceremonial. A protocol can preserve a perfect record of a bad measurement. We do not yet have an opportunity ledger showing how often each control catches a problem versus merely delaying work.
+
+What the system can do is narrower:
+
+- make data roles and openings durable;
+- freeze a bounded experiment before outcomes arrive;
+- require an evaluator with access to evidence outside the generated artifact chain;
+- exercise the path the product will actually run;
+- preserve invalid and negative outcomes;
+- attach every result to the claims and actions it may support; and
+- block automatic promotion when the required evidence does not exist.
+
+That is enough to change the behavior of the loop. The agent can still propose the next experiment and implement most of it. It can no longer convert a promising chart into a sealed result, an internal state into a delivered product event, or a successful engineering replay into authorization to post publicly without leaving a contradiction in the record.
+
+The method will be tested by inconvenience, not prose. Goose is playing eleven shows from August 13 through August 28. SetScope will change during the run. Streams will fail, songs will segue, and new covers may fall outside the catalog. The record has to retain which version heard each show, including the nights when no valid result exists. That is where the protocol becomes real.

--- a/series/the-machine-in-the-lab.md
+++ b/series/the-machine-in-the-lab.md
@@ -58,7 +58,7 @@ series: lab
               <span class="series-landing-title">{{ entry.title | remove_first: part_prefix }}</span>
               <span class="series-landing-subtitle">{{ entry.subtitle }}</span>
             </span>
-            <span class="series-landing-date">{% if entry.status == "source-draft" %}source draft{% elsif entry.status == "draft" %}draft in progress{% elsif entry.status == "collecting-results" %}collecting tour results{% elsif entry.status == "blocked-on-result" %}blocked on evidence{% else %}planned{% endif %}</span>
+            <span class="series-landing-date">{% if entry.status == "collecting-results" %}collecting tour results{% elsif entry.status == "blocked-on-result" %}blocked on evidence{% elsif entry.date %}publishes {{ entry.date | date: "%B %-d" }}{% elsif entry.status == "source-draft" %}source draft{% elsif entry.status == "draft" %}draft in progress{% else %}planned{% endif %}</span>
           </span>
         {%- endif -%}
       </li>


### PR DESCRIPTION
## Summary

- schedules Parts 2-6 for August 18, 21, 24, 27, and 30 at 08:00 EDT
- records independent structural, evidence, and rendered-readability passes for every remaining article
- keeps Part 7 in `_drafts`, without a publication date, with `published: false` and all result placeholders intact
- shows upcoming publication dates on the series page without exposing future article URLs

## Verification

- `bundle exec jekyll build`
- `bundle exec jekyll build --future`
- normal build omits Parts 2-6
- future build renders Parts 2-6
- both builds omit Part 7
- final rendered readability pass at 375 px found no overflow
