### PR TITLE
Correct autonomy framing across Machine in the Lab

### DIFF
--- a/_data/lab_series.yml
+++ b/_data/lab_series.yml
@@ -70,12 +70,12 @@
   date: 2026-08-18
   estimated_words: "3,000-3,500 words"
   purpose: "Show what happened when an experienced, PhD-trained systems researcher used an LLM agent to make an ambitious self-directed audio-research program tractable: two silent setup decisions became foundations for plausible downstream work while creating different information and meaning failures."
-  discovery_loop_role: "Show the uncontrolled loop in practice: an agent could propose, implement, run, interpret, and extend experiments faster than the researcher could inspect the premises entering the next iteration."
+  discovery_loop_role: "Show the uncontrolled loop in practice: an agent could propose, implement, run, interpret, and extend experiments while its reports failed to surface or enforce the premises entering the next iteration."
   outline:
     - title: "The deletion evening"
       detail: "Open on deleting two notebooks, retracting two articles, and taking down a listening study after friends had already spent time on it."
     - title: "The audio-research project"
-      detail: "Preserve the complete chronology for a standalone reader: automatic set detection was the original goal; the corpus and apparent power of audio features pulled the project into the Type I/Type II improvisation detour where the two notebooks failed; SetScope later returned to the original target. Establish the author's research background, corpus, labels, and why an LLM agent made work at this scale possible. Treat the PhD as context for the supervision problem, not evidence that a result must be correct."
+      detail: "Preserve the complete chronology for a standalone reader: automatic set detection was the original goal; the corpus and apparent power of audio features pulled the project into the Type I/Type II improvisation detour where the two notebooks failed; SetScope later returned to the original target. Establish the author's research background, corpus, labels, and why an LLM agent made work at this scale possible. Treat the PhD as evidence that the constraints were understood and explicit, while making clear that expertise cannot reveal a violation the autonomous system neither blocks nor reports."
     - title: "Notebook 1"
       detail: "Reconstruct the performance-level train/test leak, why the resulting numbers looked compelling, and why no downstream result could be repaired after the boundary was crossed."
     - title: "Notebook 2"
@@ -94,11 +94,13 @@
     - "In empirical work, setup is not preliminary plumbing; setup is the experiment."
     - "LLM-generated research can be invalid while the code, charts, and prose all look professional."
     - "The cost of a hidden assumption grows with every artifact the agent produces before surfacing it."
+    - "An autonomous research system must prevent or report violations of explicit constraints; requiring the operator to reconstruct every run defeats the premise."
     - "Different setup failures require different remedies: protecting independence cannot establish that a measurement corresponds to the phenomenon in the claim."
   excludes:
     - "Do not explain the complete R-1 through R-11 governance system here."
     - "Keep Q01 and Q02 to a compact account of the project's immediate response: the new discipline could retire or narrow questions, but had not yet solved measurement validity. Part 4 owns the later failure of those internal gates; Part 6 owns the mature operating protocol."
     - "Do not present the current SetScope engineering result as the resolution."
+    - "Do not make the lesson that the author should personally inspect every split, constant, or generated artifact. Preserve responsibility for publication while locating the system failure in missing enforcement and disclosure."
 
 - slug: the-holdout-is-a-one-way-door
   title: "Part 3. The Holdout Is a One-Way Door"

--- a/_drafts/the-machine-in-the-lab-series-architecture.md
+++ b/_drafts/the-machine-in-the-lab-series-architecture.md
@@ -21,7 +21,7 @@ The ordinary [editorial plan](/series/the-machine-in-the-lab/editorial-plan/) re
 
 ### Controlling question
 
-What has to change when an LLM agent can implement empirical research faster than its supervising researcher can inspect the methodological decisions embedded in that implementation?
+What has to change when an LLM agent can implement empirical research while silently violating constraints it was explicitly given, then carry those violations into the next experiment?
 
 ### Series answer
 
@@ -111,7 +111,7 @@ Part 6 is not a fourth boundary. It is the operating protocol that coordinates a
 The series is also a field report about automated experimental loops. This connection should be visible to readers following the new generation of systems that propose, execute, evaluate, and revise experiments, including the contemporary company Discovery Loop, without turning the series into commentary about a company whose implementation is not public.
 
 1. Part 1 establishes why automating the loop has become a live research and systems objective.
-2. Part 2 shows an uncontrolled loop producing plausible experimental state faster than its premises could be inspected.
+2. Part 2 shows an uncontrolled loop producing plausible experimental state while failing to surface or enforce the premises carried into the next iteration.
 3. Part 3 identifies the information problem: iteration changes what the agent and operator know, so independence must be represented as lineage rather than file placement.
 4. Part 4 identifies the evaluator problem: the loop can optimize a reproducible proxy that does not measure the named phenomenon.
 5. Part 5 identifies the execution problem: the loop must exercise the actual input, transport, controller, and display path rather than only its strongest component.
@@ -124,7 +124,7 @@ The recruiting signal should come from the technical fit. Parts 1 and 6 may name
 
 Each rung depends on the one before it. A draft that jumps past a rung has broken the series even if every sentence in the draft is individually true.
 
-### S1. Cheap research-like production changes what must be inspected
+### S1. Cheap research-like production changes what must be enforced and disclosed
 
 LLMs participate in literature search, writing, review, code, analysis, and hypothesis generation. They can contribute to verifiable work, and they make complete-looking scholarly artifacts cheap to produce. That observation does not establish a general rate comparison between production and verification costs. It creates the narrower question that controls the series: what evidence outside the generated artifact chain judges each output?
 
@@ -239,9 +239,9 @@ Without Part 1, the series becomes a personal tool-failure story and loses the r
 
 ### Standalone contract
 
-A reader should understand how two small, plausible implementation choices invalidated a large body of work, why ordinary code review did not surface them, and why the author shares responsibility for accepting the outputs.
+A reader should understand how two small, plausible implementation choices invalidated a large body of work, why the autonomous system neither blocked nor reported them, and why responsibility for publication is different from manually reconstructing every experiment the system claims to have completed.
 
-The author should be introduced as an experienced, PhD-trained systems researcher attempting an ambitious self-directed research program with LLM assistance. The credential is not an appeal to authority. It establishes that conventional research training did not automatically solve the supervision problem created by the agent's speed.
+The author should be introduced as an experienced, PhD-trained systems researcher attempting an ambitious self-directed research program with LLM assistance. The credential is not an appeal to authority. It establishes that the constraints were understood and written down. The failure was not ignorance of holdouts or implementation fidelity; it was that the system could violate explicit constraints without enforcing or disclosing them.
 
 The existing *Two Notebooks Lost* file remains contemporaneous source material rather than a contract-compliant series draft. Its phrase "the question I started with" refers to the first jam-research notebook question, not the origin of the full Zabriskie audio project. Part 2 will be a separate series draft built from that source. It needs the full set-detection-to-jam-detour chronology and a selective compression of the later governance coda assigned to Parts 4 and 6. This architecture does not authorize changing the contemporaneous source file itself without author approval.
 
@@ -263,8 +263,8 @@ How can mostly correct code produce research that must be discarded in full?
 6. The failures share a propagation mechanism but create different methodological debts. Notebook 1 invalidated independence because information crossed a boundary. Notebook 2 first violated its plan and then exposed the separate need to justify that an operational measurement corresponds to the named phenomenon.
 7. Part 3 follows the first debt through the holdout, caches, derivatives, and human adaptation. Part 4 returns to the second debt after a much stronger review process still confuses a consistent measurement chain with the claimed acoustic event.
 8. The attempted deletion that became archival and the request for progress that produced paperwork show the same lower-stakes bias toward plausible forward action.
-9. The human accepted the framing, read the artifacts, published the claims, and incurred social costs before reopening the setup.
-10. The failure is therefore a property of the human-agent system: machine speed and plausible output combine with human trust and commitment.
+9. The reports presented the explicit constraints as satisfied, and the author used those reports to publish claims and involve other people's time.
+10. The author remains responsible for publication, but the system failure is the absence of enforcement and disclosure. Requiring manual reconstruction of every completed run would negate the autonomy being evaluated.
 11. The improvisation questions encountered during the detour were genuinely interesting but too dependent on disputed labels and operational definitions to yield the clean answer the early work implied.
 12. A compact coda records the immediate response: the first written discipline retired Q01 before audio loaded and forced Q02 into a narrower, caveated claim. This belongs here as contemporaneous history, not as proof that the new process solved validity.
 13. Part 4 owns the later demonstration that those internal gates could still preserve a meaning error. Part 6 owns the mature operating protocol. Part 5 does not inherit Q01 or Q02.
@@ -279,11 +279,11 @@ Contemporaneous user-authored postmortem, retained repository history, invalidat
 
 ### Required counterarguments
 
-- A competent researcher should inspect their own split and constants.
+- A competent researcher remains responsible for claims they publish.
 - These failures could occur with a junior human assistant.
 - A long checklist may remove the speed benefit that motivated agent use.
 
-The post should concede all three. The author's research background makes the first objection more important, not less: expertise did not remove responsibility or confer immunity. The contribution is the speed and propagation documented inside this human-agent project, not a general causal estimate or the discovery that researchers remain responsible.
+The post should concede all three without accepting the premise that autonomy requires the researcher to reperform every mechanical check. The author remains responsible for publication. The system being evaluated is responsible for enforcing or disclosing explicit constraints it claims to have followed. If every split and constant must be reconstructed manually before any output can be used, the system is a fast implementation assistant, not an autonomous researcher. The contribution is the speed, silent violation, and propagation documented inside this project, not a general causal estimate.
 
 ### Standalone context requirement
 
@@ -863,7 +863,7 @@ Some ideas must recur because they are the throughline. They should gain meaning
 
 - **The surface looks complete:** scholarly prose in Part 1, notebooks in Part 2, audit trails in Part 4, percentages and UI in Part 5.
 - **The outside judge:** primary sources and evaluators in Part 1, split audits in Part 3, audio in Part 4, source frames and complete-product scoring in Part 5, sealed and prospective evidence in Part 6. Each judge still requires an independence and construct check of its own.
-- **The human remains inside the system:** trust in Part 2, adaptation in Part 3, primed diagnosis in Part 4, insistence on browser tests in Part 5, approval and veto limits in Part 6.
+- **The human remains inside the system:** publication responsibility in Part 2, adaptation in Part 3, primed diagnosis in Part 4, insistence on browser tests in Part 5, approval and veto limits in Part 6.
 - **Failure must change status:** invalid notebooks, contaminated caches, withdrawn dispatch, invalid browser sessions, opened engineering results, final sealed verdict.
 - **The product remains concrete:** the original song-guesser ambition in Part 2, the browser path in Part 5, the narrow live result in Part 6, and the versioned tour outcome in Part 7.
 
@@ -883,12 +883,12 @@ An adversarial review should verify that the series encounters these objections 
 
 | Objection | Required location | Required answer |
 | --- | --- | --- |
-| Humans make all of these errors | Parts 1 and 2 | Yes. The general point is not uniquely machine-created misconduct; the case-specific claim concerns rapid propagation, plausible surface quality, and changed supervision demands in this project. |
+| Humans make all of these errors | Parts 1 and 2 | Yes. The general point is not uniquely machine-created misconduct; the case-specific claim concerns rapid propagation, plausible surface quality, and a system that neither enforced nor disclosed explicit constraints. |
 | The adjacent example is a fan product, not a paper | Part 1 | Yes. That is the point: a serious science-shaped artifact can exist outside the institutions where research-quality debates are usually located. It is not presented as misconduct, proof of invalidity, or evidence that its creator used an LLM. |
 | An anonymous example cannot be independently inspected by the reader | Part 1 | Correct. The public post may use it only as a nonessential illustration of a category already supported elsewhere. The private dossier preserves the source for editorial audit; the series' substantive validity argument comes from the author's named case. |
 | There is no counterfactual for how much time the LLM saved | Parts 1 and 2 | Correct. Treat "weeks into hours" as the author's documented project estimate, not a causal productivity measurement or population claim. |
 | One person's labels can still be excellent | Part 4 | Yes. Reliability is unmeasured, not disproven. Expertise and agreement answer different questions, and the series' own labels require the same scrutiny. |
-| The notebooks failed because the author did not review the work | Part 2 | Yes. Human responsibility is part of the causal system, not a rebuttal to it. |
+| The author should have reviewed every split and constant personally | Part 2 | The author remains responsible for publication, but this is not an answer to the autonomy problem. The constraints were explicit and the reports presented them as satisfied. A system that requires manual reconstruction of every run is not autonomously running the research process. |
 | Preregistration and clean splits solve the problem | Parts 3 and 4 | They protect confirmation and information boundaries but do not establish construct validity. |
 | Listening is subjective | Part 4 | Report that the historical ten-case check used one outcome-aware author-listener and therefore did not estimate agreement. Preserve ambiguity, and describe neutral presentation or multiple raters as stronger future designs rather than properties of the original evidence. |
 | A frozen plan can preserve a bad construct more efficiently | Parts 4 and 6 | Yes. Durability protects provenance and permissions; it does not establish meaning. A different evidence path must still challenge the construct. |

--- a/_posts/2026-08-18-two-notebooks-lost.markdown
+++ b/_posts/2026-08-18-two-notebooks-lost.markdown
@@ -16,9 +16,9 @@ Between them, the notebooks represented a little more than a week of nearly cont
 
 All of it came down because each notebook contained a silent setup decision that invalidated what followed. The decisions were different. One crossed an information boundary. The other changed what the experiment was measuring. In both cases, most of the code worked exactly as written.
 
-This is a postmortem about what an LLM agent did, but it is not an attempt to assign the mistake to the machine and walk away clean. I asked the agent to move quickly. I accepted its framing of the work. I read the charts and the prose and did not trace the setup all the way back to the data. The project moved faster because of the agent, and the failures traveled at the same speed.
+This is a postmortem about what an LLM agent did, but publication was still my decision. I asked the agent to move quickly, then published work from reports that presented the stated requirements as satisfied. I did not independently reconstruct every split or trace each setup decision back to the raw data. Doing that after every run would have defeated the reason for delegating the research process. The failure was that the system could violate an explicit method without blocking the work or disclosing the violation, then present everything downstream as finished.
 
-I have a PhD and have spent much of my career doing systems research. That background helped me recognize the failures once they were visible. It did not stop me from accepting their premises while they were hidden inside a large volume of competent-looking work.
+I have a PhD and have spent much of my career doing systems research. That matters because these were not rules I did not know to write. My background helped me specify the constraints and recognize the failures once they became visible. It could not make an undisclosed violation visible inside a large volume of competent-looking work.
 
 ## The project before the notebooks
 
@@ -44,7 +44,7 @@ Once I knew that, there was no honest adjustment to the reported number. The lea
 
 I withdrew Notebook 1 after four days, wrote a short list of things not to do again, and started over. Its files remained in the working tree until May 4.
 
-The lesson I should have written was larger: a split I did not personally inspect was not a split I had established.
+The larger lesson was not that every split required my personal inspection. It was that a split the system could violate without stopping or reporting the violation had not been established at all.
 
 ## Notebook 2
 
@@ -93,9 +93,9 @@ A little later, frustrated with cleanup, I asked for some real progress that was
 
 The silence was the problem. The downstream work treated each choice as settled before I knew a choice had been made.
 
-By the time a result exists, it becomes harder to inspect its premises without wanting the premises to be right. I had charts. I had interpretations. I had articles that felt like articles I would respect if someone else wrote them. The quantity and polish of the artifacts increased the cost of asking whether the first step had been valid.
+By the time a result exists, it becomes harder to reopen its premises without wanting the premises to be right. I had charts. I had interpretations. I had articles that felt like articles I would respect if someone else wrote them. The quantity and polish of the artifacts increased the cost of asking whether the first step had been valid.
 
-I did not ask early enough. The agent did not volunteer the decision. That is the system we actually built.
+The choice never appeared as a decision requiring review. The agent did not volunteer it, and the reports treated the resulting pipeline as complete. That is the system we actually built.
 
 ## Two failures, not one
 
@@ -105,7 +105,7 @@ Notebook 1 failed because information crossed a boundary. The test evidence was 
 
 Notebook 2 failed because an implementation convenience defined the observable phenomenon. Even with a perfectly isolated test set, the pipeline would still have called several minutes of composition a jam. This is a meaning problem. It asks whether the measurement corresponds to the event named in the claim. A later experiment would pass every process gate we wrote after these failures and demonstrate that the problem was not solved by cleaner procedure.
 
-The common mechanism is acceleration. The agent could propose code, implement it, run it, interpret the output, write the article, and suggest the next experiment before I had fully inspected the premises of the first one. Every trip around the loop made the hidden choice more expensive to surface.
+The common mechanism is acceleration. The agent could propose code, implement it, run it, interpret the output, write the article, and suggest the next experiment before its own reports had surfaced the premises of the first one. Every trip around the loop made the hidden choice more expensive to expose.
 
 We eventually returned to the original set-detection problem. That return did not make the two lost notebooks irrelevant. It gave us a narrower question with an answer that could be checked during a live show. It also forced us to decide what a check actually is.
 

--- a/scripts/voice/voice-guide.md
+++ b/scripts/voice/voice-guide.md
@@ -162,9 +162,18 @@ characters.
 ### Criticism Includes The Author
 
 Strong criticism does not float above the events. The author states his own
-role in accepting an assumption, missing a check, or building the system. That
-accountability is central to the research series and should remain visible
-even when the agent made the immediate error.
+role in defining the constraints, deciding what to publish, or building the
+system. That accountability is central to the research series and should
+remain visible even when the agent made the immediate error.
+
+Responsibility for publishing a claim is not the same as a requirement to
+manually reconstruct every operation an autonomous system reports as complete.
+When Christopher supplied an explicit constraint and the system presented the
+work as satisfying it, do not rewrite the incident as a lesson that he should
+have personally rechecked every split, constant, file, or generated artifact.
+Name the actual system failure: the constraint was neither enforced nor its
+violation disclosed. If routine manual reperformance is required before any
+result can be used, the system is not autonomously running the research process.
 
 ## Academic Habits Worth Carrying Into Essays
 
@@ -292,7 +301,8 @@ Before a *Machine in the Lab* post is considered ready for author review:
 - the opening is a documented event, finding, or institutional action;
 - the article reaches the audio-research story through evidence rather than a
   generic AI transition;
-- the author's own responsibility remains visible;
+- responsibility for publication remains visible without turning autonomy into
+  a requirement that the author manually reperform every reported check;
 - every number is attached to its population and methodological boundary;
 - later knowledge is not placed into the mouth of the earlier narrator;
 - the ending creates a real reason to read the next part;

--- a/series/the-machine-in-the-lab.md
+++ b/series/the-machine-in-the-lab.md
@@ -15,7 +15,7 @@ image_card_type: summary_large_image
 </p>
 
 <p class="series-landing-meta">
-  I have a PhD and years of systems-research experience. That background did not prevent me from accepting either result. The project began with automatic song and set detection. The recordings pulled it into harder questions about improvisation. After both notebooks failed, I returned to the original goal: build the live song guesser.
+  I have a PhD and years of systems-research experience. These were not rules I did not know to write: both methods stated constraints the system later violated. I worked from the reports because an autonomous researcher that must be manually reconstructed after every run is not autonomous. The project began with automatic song and set detection. The recordings pulled it into harder questions about improvisation. After both notebooks failed, I returned to the original goal: build the live song guesser.
 </p>
 
 <p class="series-landing-meta">


### PR DESCRIPTION
## Summary
- correct Part 2 and the series landing page so publication responsibility is not confused with manually reperforming autonomous work
- state the actual failure: explicit constraints were neither enforced nor their violations disclosed
- update the canonical series plan, argument architecture, and shared voice guide to prevent future editorial passes from restoring the bad framing
- audit Parts 3 through 7 and preserve their legitimate uses of independent human or end-to-end evidence

## Verification
- repository-wide targeted language audit completed
- Jekyll production build succeeds
- Jekyll future-date build succeeds and renders corrected Part 2
- git diff --check passes