### PR TITLE
Keep The Whole Night on August 17

### DIFF
--- a/_posts/2026-08-17-the-whole-night.markdown
+++ b/_posts/2026-08-17-the-whole-night.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "The Whole Night"
-date:   2026-08-17 20:00:00 -0400
+date:   2026-08-17 19:00:00 -0400
 group: ai
 categories: ai zabriskie development
 ---


### PR DESCRIPTION
## What changed

Moves the post timestamp one hour earlier so GitHub Pages keeps the permalink and displayed publication date on August 17 instead of normalizing it to August 18 UTC.

## Why

The local preview and intended publication URL use `/2026/08/17/the-whole-night.html`. The first Pages artifact instead emitted `/2026/08/18/the-whole-night.html` and displayed `18 Aug 2026`.

## Impact

The public URL and displayed date now match the intended August 17 publication date.

## Validation

- Clean Jekyll build passed
- Confirmed the generated August 17 path exists
- Confirmed no August 18 copy is generated
- Confirmed page metadata displays `17 Aug 2026`
- `git diff --check` passed