### PR TITLE
Rewrite remaining Machine in the Lab posts

### DIFF
--- a/_data/lab_series.yml
+++ b/_data/lab_series.yml
@@ -4,7 +4,7 @@
 
 - slug: science-at-llm-speed
   title: "Part 1. Science at LLM Speed"
-  subtitle: "Research-like output is cheap. Valid claims still need an outside judge."
+  subtitle: "Research-like output is cheap. A valid claim still needs evidence that can show it is wrong."
   url: /series/the-machine-in-the-lab/science-at-llm-speed/
   status: published
   date: 2026-08-15
@@ -64,7 +64,7 @@
 
 - slug: two-notebooks-lost
   title: "Part 2. Two Notebooks Lost"
-  subtitle: "The code was mostly right. The experiments were already lost."
+  subtitle: "The first collapsed under validation. The second repeated a mistake it had already named."
   url: /series/the-machine-in-the-lab/two-notebooks-lost-series/
   status: scheduled
   date: 2026-08-18
@@ -226,7 +226,7 @@
 
 - slug: what-we-built-instead
   title: "Part 6. A Discovery Loop That Can Say No"
-  subtitle: "Bound the agent, preserve the failures, and let the evidence limit the claim."
+  subtitle: "A strong result should authorize only the next step its evidence can support."
   url: /series/the-machine-in-the-lab/what-we-built-instead/
   status: scheduled
   date: 2026-08-30

--- a/_posts/2026-08-15-science-at-llm-speed.markdown
+++ b/_posts/2026-08-15-science-at-llm-speed.markdown
@@ -117,11 +117,11 @@ I then changed the task. Instead of improving SetScope's song guesses, I asked t
 
 The recordings seemed to offer a way to investigate harder questions about improvisation: whether musical features could identify when a performance left its composed structure, whether different forms of jamming had measurable signatures, and whether those signatures generalized across performances. Those questions were more interesting than simple song identification. They were also much harder to define.
 
-I am a PhD-trained systems researcher. I know what a holdout is, and I know why an experimental method has to match its implementation. That was not enough. The first notebook expanded from song recognition into several improvisation questions without maintaining one prospective test set that remained untouched while the system chose its next experiments.
+I am a PhD-trained systems researcher. I know what a holdout is, and I know why an experimental method has to match its implementation. That was not enough. The first notebook expanded from song recognition into several improvisation questions without preserving one final test capable of evaluating the path the system chose.
 
-The audit found several problems, not one neat leak. A same-song classifier had been evaluated on different pair rows that could still reuse an individual performance. A stricter rerun showed that holding out a performance was not the same as holding out every performance of its song. More decisively, a published Type II improvisation detector failed on 44 held-out cases. One of its three signatures never fired, their conjunction never fired, and the remaining signatures mistook changes inside composed songs for improvisation. I withdrew the result and started again.
+The audit found several problems, not one neat leak. Most decisively, a published Type II improvisation detector failed on 44 held-out cases and mistook changes inside composed songs for improvisation. I withdrew the result and started again.
 
-For the restart, I locked a new split over many of the same recordings and wrote a methodology framework that explicitly warned against defining improvisation with fixed 90-second boundaries. I gave that framework to the agent. The first implementation nevertheless reused the same hard-coded default. The source code named it the old notebook's rule; the research loop never stopped to report that the code contradicted the declared method. Working from those reports, I put two draft dispatches online at their direct URLs and sent friends listening assignments built from the resulting analysis.
+For the restart, I locked a new split over many of the same recordings and wrote a methodology framework that explicitly warned against fixed ninety-second jam boundaries. The first implementation reused them anyway. The research loop never stopped to report that the code contradicted the declared method. Working from those reports, I put two draft research posts online at their direct URLs and sent friends listening assignments built from the analysis.
 
 The consequences were larger than the lines of code that caused them. I was responsible for putting the work online and involving other people's time. But the lesson could not be that I should manually reconstruct every split and trace every constant before accepting any result. A system that requires that level of supervision is not running the research process autonomously. It is generating work for a human auditor. The system needed to prevent violations of its rules or report them when they occurred. It had done neither. I deleted the second notebook, took the drafts down, and abandoned the listening study.
 
@@ -139,13 +139,13 @@ This is the first of seven posts in [The Machine in the Lab](/series/the-machine
 
 Part 2 reconstructs the two notebooks I deleted: the questions they tried to answer, the results that looked convincing, and the small implementation choices that invalidated nearly everything built on top of them.
 
-Part 3 is about the boundary we kept crossing. A holdout cannot remain independent if an agent is allowed to inspect it, explain a miss, and then use that explanation to choose the next experiment. The post follows the project from written instructions about data leakage to data roles and permissions the research system could actually enforce.
+Part 3 is about the boundary we kept crossing. A holdout cannot remain independent if an agent is allowed to inspect it, explain a miss, and then use that explanation to choose the next experiment. The post follows the project from written instructions about data leakage to durable data roles and a record of which evidence each later version had already used.
 
 Part 4 follows the review system we built next. Multiple agents audited the code, checked the methodology, and agreed that the experiment was ready. Every check passed. The experiment still reached the wrong acoustic interpretation for a reason the review process had not been designed to see.
 
 Part 5 moves the experiment into the browser. It covers the audio-capture path, the difference between a classifier result and a viewer-visible decision, and the first genuinely new Goose show the system heard while it was happening.
 
-Part 6 describes what we built instead of another long research prompt: typed experiment state, provenance, explicit permissions, preserved failures, and a promotion boundary that the agent cannot silently cross.
+Part 6 describes what we built instead of another long research prompt: durable data roles, frozen experiments, preserved failures, and a separate decision about what each result is allowed to change.
 
 Part 7 returns after Goose's August run with the operational record. It will report the versions that actually ran, the guesses they emitted, the misses and false switches, the capture failures, and the repairs made between shows without compressing an evolving live product into one flattering score.
 

--- a/_posts/2026-08-18-two-notebooks-lost.markdown
+++ b/_posts/2026-08-18-two-notebooks-lost.markdown
@@ -18,7 +18,7 @@ An LLM agent was running much of this loop. I supplied the recordings, the quest
 
 The speed was exhilarating. It was also the problem. In eight days the project produced more code, figures, findings, public pages, and listening exercises than I could keep in my head at once. When the notebook failed, it did not fail for one tidy reason. An audit exposed several different problems at the same time.
 
-By April 30, three Notebook 1 dispatches had appeared on the public site. One had already been pulled as its taxonomy shifted. A replacement had briefly appeared and then returned to draft after review. That evening I withdrew the notebook's central published Type II result. I abandoned Notebook 2 on May 6.
+By April 30, three Notebook 1 research posts had appeared on the public site. One had already been pulled as its taxonomy shifted. A replacement had briefly appeared and then returned to draft after review. That evening I withdrew the notebook's central published Type II result. I abandoned Notebook 2 on May 6.
 
 ## Notebook 1: the published claim fails its held-out test
 
@@ -30,13 +30,13 @@ A related retrieval experiment had a different problem. Even when it held out on
 
 Those were corrections to song-recognition experiments. They were not the event that killed Notebook 1.
 
-The published claim that collapsed was about improvisation. The notebook had proposed three acoustic signatures for what jam-band listeners call Type II playing, where a performance leaves the song's ordinary composed structure. A public dispatch used the November 9, 1998 Bathtub Gin from UIC as its central example.
+The published claim that collapsed was about improvisation. The notebook had proposed three acoustic signatures for what jam-band listeners call Type II playing, where a performance leaves the song's ordinary composed structure. A public research post used the November 9, 1998 Bathtub Gin from UIC as its central example.
 
 The signatures looked convincing on the performances used to develop them. Then the agent ran them on 44 held-out cases: 11 community-annotated Type II performances and 33 composed or Type I controls. One of the three signatures never fired. All three never fired together, even though the public research post was built around that combination. The other two produced more false positives than the argument could survive, including on Reba and several Goose songs with contrasting composed sections.
 
 The detector was reading changes inside the composition as departures from the composition. Its first-ninety-seconds, middle, and last-ninety-seconds windowing assumed a song form that many of the songs did not have.
 
-That result was decisive. The public dispatch's central claim did not generalize beyond the examples that had shaped it, so I withdrew it on April 30.
+That result was decisive. The public post's central claim did not generalize beyond the examples that had shaped it, so I withdrew it on April 30.
 
 The same audit also forced a harder conclusion about the notebook as a whole. It had accumulated many questions, datasets, thresholds, and evaluations without keeping one final test set out of sight from beginning to end while the program chose its next steps. Some individual reruns could produce more honest estimates. The notebook itself could no longer produce an independent final verdict on the research path it had already taken.
 
@@ -58,9 +58,9 @@ Then the first Notebook 2 analysis set `HEAD_S = 90` and `TAIL_S = 90`.
 
 The source code did not hide the constants. Its comments even called the calculation the "N1 default." What the research loop failed to do was notice that the implementation contradicted the notebook's own declared method and stop the experiment there.
 
-Instead, the work continued. The notebook expanded the corpus, compared several audio measurements, audited community labels, explored clusters, generated per-window heat maps, and drafted two long listening guides. Two new listening assignments went out: one around three Ghost performances, and another around Sand, Light, the 1994 Bangor Tweezer, and the 2024 Bethel Bathtub Gin. The two associated dispatches remained drafts, although they were accessible at their direct URLs while I worked on them.
+Instead, the work continued. The notebook expanded the corpus, compared several audio measurements, generated charts, and produced two listening assignments and two long research posts. The posts remained drafts, although they were accessible at their direct URLs while I worked on them.
 
-By the time the mismatch was identified, the fixed boundary had propagated through the analyses, figures, draft dispatches, and listening exercises.
+By the time the mismatch was identified, the fixed boundary had propagated through the analyses, figures, draft posts, and listening exercises.
 
 The mistake was especially difficult to excuse because Notebook 1 had already demonstrated it and Notebook 2 had already written down the rule that should have prevented it. This was not an unknown edge case. It was a named failure mode reintroduced by the first implementation.
 

--- a/_posts/2026-08-24-when-every-check-passes.markdown
+++ b/_posts/2026-08-24-when-every-check-passes.markdown
@@ -11,113 +11,72 @@ permalink: /series/the-machine-in-the-lab/when-every-check-passes/
 categories: ai research zabriskie agents
 ---
 
-On May 23, I published an audio-research result after it passed every check the project required.
+On May 23, I published an audio-research result after every gate used to approve publication returned green. Then I read the post, pressed play on its first example, and heard the interpretation fall apart.
 
-Those checks existed because the two earlier notebooks had failed. We had added explicit plans, reviews, artifact audits, and publication approvals to prevent another plausible result from outrunning its evidence.
+This was not an experiment on SetScope, the Goose song guesser. It came from the separate Phish detour described earlier in this series. The question was whether audio features could locate the end of an improvised jam, where the band returned to the composed song.
 
-The plan had been reviewed. Five advisor conditions had been applied. The figure-generation script passed three byte-faithfulness audits. The numbers in the prose traced to saved artifacts. A content audit found no unsupported numerical claims. A second advisor review approved the complete dispatch. I approved a soft launch and then a hard launch. The page went live with a homepage card and a final [publication log](https://github.com/cmeiklejohn/zabriskie-audio-research/blob/bfd8b0aa360b7898d7f50fa4aa6f119a9783d4d5/docs/logs/dispatch-002-publication.html).
+The process around the experiment was elaborate because two earlier notebooks had already failed. The plan was reviewed. Advisor conditions were added. The implementation, saved numbers, figures, prose, and final page were audited against one another. A second review approved the complete research post. I approved a soft launch and then a public one. The [publication log](https://github.com/cmeiklejohn/zabriskie-audio-research/blob/bfd8b0aa360b7898d7f50fa4aa6f119a9783d4d5/docs/logs/dispatch-002-publication.html) recorded every step.
 
-Every recorded check was green.
+Every gate used to authorize publication was green.
 
-Then I read the blog post and listened to the first example.
-
-The listener mark sat two seconds before the audible end of the song.
+The first listener mark sat two seconds before the audible end of the music.
 
 ## The result we thought we had
 
-The experiment concerned the end of a jam. In the project's labeling system, a listener marked the point where improvisation ended and the band returned to composed material. We compared those marks against an onset-density changepoint detector, a signal-processing method intended to find a large change in musical activity.
+The experiment compared human marks for the end of a jam with a detector based on changes in onset density, a rough measure of how frequently new musical events begin. It found large changes over time, removed candidates too close to the track edges or one another, and required at least two candidates to survive. When they did, it selected the last one. Otherwise it abstained.
 
-The reported result was that the detector recovered the listener-marked end on three of four Sands and three of four Bathtub Gins within a song-specific tolerance. The blog post interpreted this as evidence that the end of a jam was acoustically recoverable as a band-level return to composed structure, even though the beginning remained difficult to detect.
+That last part matters. The detector did not identify a return to composed music directly. It selected a late acoustic change and compared its time with a listener's mark.
 
-That interpretation was the reason the result mattered. Agreement between timestamps by itself is not very interesting. If the detector and listener were identifying the same musical event through different paths, we had evidence that a community concept could be grounded in an acoustic change.
+The full evaluation contained 16 tracks: ten listener-marked positives and six negatives. Eight of the positives belonged to the two multi-performance song groups, four Sands and four Bathtub Gins; Reba and Tweezer appeared once each. The headline result came from those two larger groups. The detector landed within plus or minus 60 seconds of the listener mark on three performances of each song, six of eight in total. We interpreted those agreements as evidence that the return from improvisation to composition created a detectable acoustic change.
 
-The first example was Sand from July 3, 2000. The listener mark was 11:56, the detector prediction was 11:42, and the music ended around 11:58. The archived track continued through audience and tail audio until 13:23. When I played the clip, the marked event did not initially sound like an abstract structural boundary. It sounded inseparable from the song ending.
+The first example was Sand from July 3, 2000. The listener mark was 11:56. The detector predicted 11:42. The music ended around 11:58, although the archive file continued through applause and tail audio until 13:23.
 
-The pipeline had answered the scoring question correctly: the predicted time was near the labeled time. I no longer knew whether either timestamp supported the sentence we had published.
+When I listened, the mark did not sound like an abstract structural boundary. It sounded inseparable from the ending of the song. The scorer was right that the two timestamps were close. I no longer knew whether their proximity supported the sentence we had published.
 
-## The first diagnosis
+## The first correction was wrong too
 
-The published six-of-eight verdict covered four Sands and four Bathtub Gins. The broader ten-case positive set also contained a Reba and a Tweezer. Five of the six reported hits had a listener mark within two minutes of the archive track boundary. Two were within a minute.
+The first explanation seemed obvious. Perhaps the listeners had marked the ends of performances rather than returns to composition.
 
-The first explanation seemed obvious. Perhaps the labels were systematically anchored to the end of the musical performance rather than the return to composition. The labeling instructions allowed two cases: mark the return to composed material, or mark track end when the jam continued through the end of the song. The analysis had silently assumed every value had the first meaning.
+The labeling instructions allowed two meanings for `jam_end`: mark the return to composed material, or mark the end of the track when the improvisation continued through the ending. The analysis treated those cases as if they all meant the first thing.
 
-Under that explanation, the detector might have been doing useful structural work while the labels were wrong. One failed Bathtub Gin appeared to support the inversion: the detector found a shift around 14:50, while the label sat at 16:11, almost exactly at track end.
+Several successful cases occurred near the end, which made the label problem look systematic. We withdrew the result and wrote the initial correction around that diagnosis.
 
-We wrote the withdrawal record around that diagnosis. The central claim was unsupported because label agreement could not establish recovery of composed structure if the labels represented a different event.
+Then I listened to all ten positive cases in the 16-track evaluation.
 
-Listening to all ten cases made the diagnosis mostly wrong.
+Eight listener marks were genuine returns to composed music. One Bathtub Gin used the permitted track-end interpretation because there was no composed return. One Reba mark did not survive review at all. The old withdrawal record says nine of ten were composed returns, but its own case table records eight; I am using the case-level record here.
 
-## The labels were better than the explanation
+The labels were not systematically anchored to track endings. In this selected set, the band often returned to the song shortly before the music ended. What looked like evidence of bad labeling was mostly a property of the performances.
 
-I used a one-off page that presented each listener mark and detector prediction with audio controls. Phish often returns to the song shortly before the music ends. The proximity that had looked like evidence of bad labels was, in most cases, a property of the performance structure.
+That did not restore the published result.
 
-The [preserved review record](https://github.com/cmeiklejohn/zabriskie-audio-research/blob/bfd8b0aa360b7898d7f50fa4aa6f119a9783d4d5/docs/logs/dispatch-002-withdrawal.html#L144-L170) contains a contradiction I missed at the time. Its ten-row case table records eight listener marks I heard as composed returns, one Bathtub Gin mark as track end without a composed return, and one Reba for which I wrote that both the listener and detector marks were wrong. The summary immediately below the table says nine of ten listener marks were composed returns. Those statements cannot both be true.
+The detector was designed to choose the last large acoustic change in a track. Many valid returns also happened late. Agreement between the two timestamps could therefore mean that the detector recognized the return, or that both the return and the detector's preferred change happened near the ending. The original experiment did not distinguish those explanations.
 
-The table is the case-level record, so I am using eight here and treating the old nine-of-ten summary as an error. The cases were:
+The listening review could invalidate our first interpretation and our first correction. It could not validate a replacement result. I was one outcome-aware listener reviewing selected positive cases after publication. The exercise could not estimate false negatives, specificity, or behavior over the full corpus.
 
-- **Sand, July 3, 2000:** composed return; original score: hit; 1:27 to the archive boundary.
-- **Sand, December 31, 2010:** composed return; original score: hit; 0:36 to the archive boundary.
-- **Sand, July 28, 2017:** composed return; original score: hit; 1:26 to the archive boundary.
-- **Sand, October 26, 2018:** composed return; original score: miss; 2:11 to the archive boundary.
-- **Bathtub Gin, July 10, 1999:** track end; original score: miss; 0:05 to the archive boundary.
-- **Bathtub Gin, July 20, 1998:** composed return; original score: hit; 0:58 to the archive boundary.
-- **Bathtub Gin, February 14, 2003:** composed return; original score: hit; 2:06 to the archive boundary.
-- **Bathtub Gin, February 28, 2003:** composed return; original score: hit; 1:45 to the archive boundary.
-- **Reba, August 16, 1993:** listener and detector marks both rejected; original score: miss; 5:59 to the archive boundary.
-- **Tweezer, November 2, 1994:** composed return; original score: hit; 2:07 to the archive boundary.
+The honest conclusion was narrower: the original score did not establish that the detector recognized a return to composed music.
 
-Eight of ten is enough to reject the first diagnosis that the labels were systematically anchored to track end. One label used the second permitted interpretation. One label did not survive the review at all. Most of the suspicious proximity came from the way these performances returned to the song and then ended.
+## What all the checks had checked
 
-## What the corrected case record could say
+Nothing in the approval chain was fake. It verified that the implementation followed the plan, the figure matched the saved result, the prose matched the figure, and the required reviews occurred.
 
-My ten-case listening review has important limitations. I was one listener. I knew the experiment had failed, knew the suspicious pattern, and saw the selected positive cases. This was an outcome-aware, post-publication review, not blinded annotation or an inter-rater agreement study. Because I reviewed selected positives, the exercise cannot estimate false negatives, specificity, or the detector's behavior over the full corpus.
+Every check followed the same chain. The label fed the scorer. The scorer produced an artifact. The artifact produced a figure. The figure supported the prose. Reviewers traced the claim backward through that chain and found it internally consistent.
 
-The review could reject our first explanation, but it did not establish the strong replacement explanation written into the withdrawal summary. All seven hits in the broader table were composed-return cases whose marks occurred 36 to 127 seconds before the archive boundary. The valid Sand miss occurred at 2 minutes 11 seconds, only four seconds beyond the largest hit gap. The Gin miss used the track-end interpretation, and the Reba mark at 5 minutes 59 seconds had itself been rejected.
+No prepublication gate required a claim-focused comparison of what was audible at both the listener and detector timestamps. The labels came from listening, but the interpretation built on their agreement had not been checked that way.
 
-The algorithm selected the final large changepoint in time order, so it was structurally biased toward late events. The selected ten-case review does not show how often that bias caused a hit or miss. It showed that the original interpretation had not been independently established, and that the first confident explanation of the failure had outrun the evidence too.
+The ambiguity was visible in the data definition. The instructions said that `jam_end` could mean either a composed return or the end of the performance. The hypothesis assumed the first meaning. A plan-to-data review should have stopped there, but our process treated the field as settled ground truth.
 
-That is not a new detector result. It is a limit on what the old result can claim.
+Traceability established where the claim came from. It did not establish that the measurement represented the musical event named in the claim.
 
-## What the gates actually checked
+## Returning to the phenomenon
 
-Nothing in the approval chain was fake. Each check answered a legitimate question:
+After the withdrawal, the project added an acoustic reality check for claims about audio. Before an analysis proceeds, and again before publication, someone has to listen at the relevant labels and predictions and record what is audible.
 
-- Did the implementation follow the plan?
-- Did the generated figure match the saved numerical artifact?
-- Did the prose accurately report the figure and result?
-- Were the planned unit, thresholds, and qualifiers preserved?
-- Were the required reviews and approvals recorded?
+Human hearing is not an infallible instrument. The first review was especially weak as a new experiment because I knew the result and the suspected failure. Later listening assignments used neutral metadata, randomized order, no preloaded explanation, and structured responses so that disagreement would survive the review.
 
-These are necessary checks. Without them, a claim can drift between plan, code, result, and prose. But every gate followed the same derivative chain. The label fed the scorer. The scorer fed the artifact. The artifact fed the figure. The figure fed the prose. Reviewers traced the claim backward through that chain and found it internally consistent.
+The value of listening was not that a human replaced the model. It was that the check encountered the underlying phenomenon through a path that did not descend from the same artifacts. The labels, scorer, chart, and prose could all share one mistaken interpretation. Audio could contradict all of them.
 
-No gate asked what was audible at the labeled and predicted timestamps.
+This is the limitation of adding more agents to one review chain. They can inspect a plan, implementation, result, and post while sharing the same blind spot. More agreement increases confidence only when a reviewer brings information capable of producing a different answer.
 
-Traceability established where the claim came from. It did not establish that the source measurement represented the musical event the claim named.
+For this experiment, that information arrived when someone pressed play.
 
-Notebook 2 had left this debt behind. Its ninety-second default made a convenient segment define what counted as a jam. The new discipline caught inherited constants and forced plans to state their assumptions, but we treated the labels in Dispatch 002 as settled ground truth. The interpretive choice moved from a constant into the meaning of a field, where the existing rules did not know to look.
-
-The most embarrassing part was that the ambiguity was documented. The labeling instructions explicitly said `jam_end` could mean return to composition or track end if no return occurred. A plan-to-data audit could have noticed that the hypothesis assumed only the first case. It did not.
-
-## A different evidence path
-
-The project added a rule requiring an acoustic reality check for claims about audio. Before an analysis proceeds, and again before publication, someone must listen at the relevant labels and predictions and record what is audible.
-
-The value of this check is not that human hearing is infallible. It is that the evidence does not descend from the same artifact chain. A waveform feature, a label, and a chart can agree because they share an assumption. Listening can contradict the interpretation through another modality.
-
-The original reality check was not independent in every sense. I was the author, knew the outcomes, and had already proposed an explanation.
-
-Later assignments were redesigned to present neutral metadata, randomize order, omit preloaded notes, and collect structured responses. That reduces some forms of priming and makes disagreement easier to inspect. It does not turn listeners into objective instruments, and it does not retroactively improve the first review.
-
-This matters because "add a human" is not a methodology. Which human? What did they know? Which cases did they hear? What categories were available? Were disagreements preserved? A domain check has its own measurement design.
-
-The first check still did something the elaborate agent process had failed to do: it returned to the underlying phenomenon. It made the published interpretation suspect, and then it made the first attempted correction suspect too.
-
-## The erratum needs evidence
-
-An erratum can repeat the original failure if it is allowed to close around the first plausible explanation. The correction needed an evidence path outside the artifacts and diagnosis that produced it.
-
-This is the limit of process-heavy review in a discovery loop. Multiple agents can inspect a plan, implementation, result, and blog post while sharing one blind spot. Adding another reviewer to the same chain increases scrutiny without necessarily creating contradiction. The evaluator has to be capable of telling the entire chain that its interpretation is wrong.
-
-For Dispatch 002, that evaluator was a person pressing play.
-
-The project eventually left the jam-classification detour and returned to the original song-identification tool. That made the output easier to name: either the screen said the song that was playing or it did not. It did not make evaluation simple. An offline score still could not say what happened between the browser and the model.
+SetScope would expose the same lesson in a product setting. An offline classifier could score well while the browser received broken audio, the controller changed songs at the wrong time, or the interface displayed the wrong state. The next useful check had to run through the product itself.

--- a/_posts/2026-08-27-the-browser-is-part-of-the-experiment.markdown
+++ b/_posts/2026-08-27-the-browser-is-part-of-the-experiment.markdown
@@ -11,128 +11,76 @@ permalink: /series/the-machine-in-the-lab/the-browser-is-part-of-the-experiment/
 categories: ai research zabriskie agents
 ---
 
-The song recognizer once identified Animal before the music started.
+SetScope once identified Animal before the music started.
 
-I had opened a Goose show in the browser, started SetScope, and watched the interface warm up over crowd noise. At sixty seconds, I watched it display Animal with 99 percent confidence. The music had not begun. That observation survives in my screenshot, not in the later transport-incident record.
+On August 12, I opened a historical Goose show in the browser and started the live song guesser from the beginning. The screen locked to Animal after 40 captured seconds of crowd and intro audio. By the time I took a screenshot at one minute, the interface displayed Animal with what it called 99 percent confidence.
 
-This was especially alarming because the system was supposed to contain a music gate. Preshow chatter and crowd noise were not merely difficult examples. They were inputs on which the song classifier should not have been allowed to make a decision at all.
+The number was not a calibrated probability. It was a rank score, and Animal led the next candidate by only 0.0022.
 
-At the time, we also had an apparently strong offline result: 46 correct predictions on 54 segmented tracks from five held-out shows, or roughly 85 percent top one. I had been using that number as evidence that we were approaching a usable live recognizer.
+The [incident record](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0477-june30-training-overlap-incident.md) established more than a suspicious screenshot. The exact June 30, 2026 performance had been used in local model fitting. At least two ten-second training crops contained mostly crowd or intro audio while carrying the Animal label. During the rehearsal, the music gate falsely declared music after 3.25 seconds and allowed a closed-set classifier to choose among songs even though no song had begun.
 
-The browser was telling me the number described something else.
+The captured stream and training file were not identical enough to claim literal waveform memorization. The correct title did not rescue the event anyway. SetScope had made a song decision on nonmusic from a performance it had already seen.
 
-That Animal rehearsal established a symptom, not its cause. We had not preserved enough of that session to prove why the premusic lock occurred. A later six-minute run, in which the system failed to admit any music at all, gave us the first captured input we could inspect from browser to recognizer.
+That failure involved training overlap, bad labels, a bad gate, a closed catalog with no safe unknown state, and a UI that called an ordinal score confidence. It did not explain every strange browser result that followed.
 
-## A song guesser, not a scientific instrument
+## What the offline number measured
 
-SetScope has a deliberately ordinary job. It listens to a Goose stream and shows a viewer its best guess about the current song. The viewer should not need the show date, a setlist, or a second fan site.
+At the time, SetScope also had an apparently strong component result. It correctly named 46 of 54 accepted, in-vocabulary, single-song tracks from five shows absent from its local fitting data, roughly 85 percent. The tracks were already cut, decoded, and known to contain one labeled song. They represented 45 of the model's 254 labels.
 
-The title on the screen is a product output. It is not a scientific finding about Goose. A browser rehearsal is a product test. Its logs can support a methodological claim about how we evaluated the system, but correctly naming Animal does not turn the application into a research instrument.
+That result answered a useful question: could the classifier recognize many pre-cut tracks under that protocol?
 
-That plain description helps clarify what the old 85 percent result actually measured. We had cut labeled audio into segments and asked the classifier to name each segment. The 54 rows were leakage-disjoint at the file, performance, and show-date levels under the frozen result. They covered only 45 of the model's 254 catalog labels, and the test began with an already decoded piece of a known music track. It was a valid but narrow component evaluation.
+It did not test whether Chrome delivered valid audio, whether the system stayed quiet during crowd noise, whether a title remained stable through a jam, whether it switched across a segue, or whether an internal decision reached the interface. Calling the number live accuracy made a component test answer for a product that had never run.
 
-It did not measure:
+SetScope's actual path was much longer. Chrome decoded the stream. macOS routed it through a virtual audio device. A capture process segmented and resampled it. A music gate decided whether the song models were allowed to run. Several model families proposed candidates. A controller decided when one candidate could replace another. Only then did the application render a title.
 
-- whether the browser audio reached the recognizer intact;
-- whether the system stayed quiet during preshow music, crowd noise, and set break;
-- how quickly a title appeared after music began;
-- whether the displayed title remained stable through a long jam;
-- whether the system detected a segue with no silent boundary;
-- what happened when the band played a song outside the catalog; or
-- whether a correct internal state reached the screen or a public chat.
+The offline evaluation began near the model. The product began in the browser.
 
-Calling 46 of 54 "live accuracy" collapsed all of those untested behaviors into one convenient percentage.
+## A separate run heard no music at all
 
-## The demonstrations got stranger
+Later that day, a different browser session ran for more than six minutes without admitting a single second of music. The song selector never ran.
 
-Animal was not an isolated miss. Browser tests produced rapidly changing song identities, long delays after all acoustic models appeared to agree, and locks authorized by a contextual rule even when the audio models favored another song. One run continued for six minutes without admitting a single second of music. The selector never ran.
+This was the opposite of the first Animal incident. It could not explain the pre-music lock, because in this session no model was allowed to make any song decision. It exposed a separate failure earlier in the audio path.
 
-It was tempting to treat each outcome as a classifier error. Animal is musically distinctive. Royal is musically distinctive. Thatch and Big Modern begin with recognizable riffs. Perhaps the features were not good enough, the candidate generator was too weak, or the temporal model was holding the wrong state.
+The saved waveform contained exact-zero gaps about 0.105 seconds long at roughly 1.1-second intervals. The signal looked loud and the segment timestamps advanced, but the music gate saw a discontinuous input. Its median score was about 0.08. The same Animal performance decoded from the read-only archive scored almost 1.00.
 
-Those were real issues, but they assumed that the model was hearing what I heard through the speakers.
+Removing an asynchronous resampler eliminated the periodic zeros but not the missing audio. Nominal ten-second segments contained only 7.3 to 8.9 seconds of decoded samples. A direct tone test localized the remaining loss to FFmpeg's AVFoundation capture path.
 
-The deployed path was longer:
+The dashboard had been measuring files declared, not audio successfully transported.
 
-1. Chrome decoded the Nugs stream.
-2. macOS routed the output through BlackHole while maintaining a monitor path to the speakers.
-3. A capture process read the virtual audio device.
-4. The runtime segmented the stream and resampled it.
-5. A music gate decided whether enough continuous music existed.
-6. Several acoustic model families generated candidates.
-7. A temporal controller decided whether a candidate could replace the current song.
-8. The application persisted state and rendered the interface.
+## Repairing the path before judging the model
 
-The offline experiment began around step six. The product began at step one.
+We replaced FFmpeg capture with a native CoreAudio helper and made the runtime account separately for source frames received, samples finalized into captured audio, and samples decoded by the recognizer. Segments also recorded signal level, exact-zero fraction, and internal dropouts. A session with missing samples became an invalid run instead of a mysterious model miss.
 
-## What the browser audio contained
+The first fresh browser run after the capture repair used the same historical Animal performance. It received 246.0 source seconds and finalized and decoded 245.93 seconds. No song was proposed during the opening crowd and intro. All four acoustic views eventually ranked Animal first, and the controller locked it 70 seconds after the estimated music onset.
 
-We saved the captured audio from the six-minute failure and inspected the waveform. The [incident record](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0506-browser-capture-input-integrity-incident.md) reports exact-zero gaps about 0.105 seconds long at roughly 1.1-second intervals.
+That valid input exposed a policy problem. One uncertain gate observation during continuous music immediately erased the accumulated window. We copied the exact captured bytes and changed only that rule: an uncertain observation waited for the next one instead of resetting state. Animal locked 40 seconds earlier.
 
-The signal was loud. Segment timestamps advanced normally. The dashboard therefore reported a healthy session. But the music gate saw a discontinuous input unlike the archive recording on which it had been developed.
+That was an exact-byte policy comparison. It showed that one controller change helped on one opened diagnostic input. It did not prove that the repaired browser path behaved the same way.
 
-The difference was large enough to measure directly. The incident summary reported a median music-gate output of about 0.08 across the browser run's scored windows and about 1.00 when the same Animal performance was decoded from the read-only archive file.
+So we ran the browser again. The next session reconciled 215.9 source seconds with 215.89 decoded seconds. Nothing was proposed during the intro. Animal became the first acoustic hypothesis after 30 admitted music seconds, all four views agreed by 60, and the displayed state locked around 70 seconds after music onset and remained stable.
 
-An early suspect was the asynchronous resampler. Removing it eliminated the periodic digital-zero pattern, but nominal ten-second capture segments still contained only 7.3 to 8.9 seconds of decoded audio. A direct tone test localized the remaining loss to FFmpeg's AVFoundation input path.
-
-The timestamps had been measuring files being declared, not samples successfully transported.
-
-This is why the browser belonged in the experiment. An archive decoder could not expose a macOS capture failure. A model benchmark could not tell us that the input contained holes. The product was producing apparent model behavior from invalid audio.
-
-## Making input validity visible
-
-We replaced the FFmpeg capture path with a native CoreAudio helper. It selected the named device directly, downmixed to mono, and wrote one contiguous sample stream into the segmenter.
-
-The more important change was accounting. The session began recording three quantities independently:
-
-- source frames received from CoreAudio;
-- samples finalized into the captured audio; and
-- samples decoded by the recognizer.
-
-A session passed transport integrity only when those clocks reconciled under the fixed 0.5-second tolerance. Each segment also reported RMS, peak, exact-zero fraction, and internal dropout counts. Startup failed if the selected device produced no callbacks. A completed capture with missing recognizer samples became an invalid run rather than a mysterious model miss.
-
-On a valid replay of Animal, 246.000 source seconds became 245.930667 finalized and decoded seconds. The timebase passed. The opening crowd and intro produced no song proposal. All four acoustic views eventually ranked Animal first, and the system locked it after seventy admitted music seconds.
-
-Seventy seconds was slower than I wanted, but it was a real latency measured from audio the model had actually received.
-
-## A valid input exposed a policy failure
-
-That valid capture exposed the next problem. One music-gate observation fell below threshold during continuous Animal. The runtime immediately cleared its accumulated audio window, delaying the lock. We copied the exact captured bytes and replayed them with one policy change: an uncertain gate window waited for the next observation instead of immediately resetting state. Nothing about the input or model changed. Animal locked forty seconds earlier.
-
-Exact-byte replay let us ask whether a policy change improved behavior without accidentally changing the browser input at the same time.
+Now the transport repair, policy change, and browser path had been tested separately.
 
 ## One song was not enough
 
-The next diagnostic started at the beginning of Dr. Darkness and allowed the Nugs player to advance naturally into Drive.
+Before the transport repair, a Dr. Darkness-to-Drive rehearsal had missed Drive, switched incorrectly to Madhuvan, and ended with more than two minutes of unaccounted capture time. We repeated the same two-song sequence after repairing the input path.
 
-The interface refreshed candidate telemetry throughout Dr. Darkness, including brief drift toward other songs, while the publication state held the correct title. When Drive began, the acoustic sources changed before the temporal controller authorized a transition. At 410 seconds, all four sources ranked Drive first and the transition model switched the held state. This was the behavior we wanted: frequently changing evidence, conservative displayed state.
+In the new run, Dr. Darkness locked after 70 seconds of admitted music. Individual model views drifted briefly during the song, but the held state did not switch. The player advanced naturally into Drive around 357 captured seconds. Drive led the selector at 400 seconds, but the controller held Dr. Darkness until all four acoustic sources and the transition model agreed at 410 seconds.
 
-The run also revealed that capture wrote 48 segments while the recognizer exited after 47. The missing tail was only 1.284 seconds, and it did not change the two song decisions when replayed. It still made the original session invalid under the fixed transport rule. Shutdown was part of the input path too.
+That was the behavior I wanted: frequently refreshed evidence, a conservative displayed state, and a real transition without requiring a silent boundary.
 
-Longer tests exposed errors that no isolated track could express. A system can name every segment correctly and still perform badly if it changes songs in the middle of a jam, refuses to switch across a segue, carries state through a set break, or assigns a debut cover to the nearest known title.
+The run still failed its final input accounting. Capture wrote 48 segments while the recognizer exited after 47, leaving a 1.284-second gap. That defect led to a fixed half-second reconciliation rule and a shutdown fix. A second exact-byte replay, this time testing final-segment draining rather than gate policy, processed all 48 segments and preserved the Dr. Darkness and Drive decisions.
 
-The evaluation surface had to expand from top one to a product record:
+Two replays had answered two different questions. The Animal gate-policy change received a fresh browser confirmation. The final-segment repair had only its exact-byte replay; another complete browser run was still required.
 
-- precision and coverage of the first stable lock;
-- time from admitted music onset to first correct evidence and stable state;
-- correct, incorrect, and abstained held-state time;
-- false stable switches and their dwell;
-- behavior during nonmusic and unknown material;
-- transition behavior across pauses and segues;
-- capture validity; and
-- separately observed UI and publication delivery.
+## The next evening's live show
 
-These metrics do not replace controlled corpus evaluation. They answer questions the corpus experiment never asked.
+On August 13, Goose played in San Diego. SetScope listened while the show was happening, using audio that had not existed during development.
 
-## The night the narrow question worked
+The [post-show audit](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0521-2026-08-13-live-show-audit.md) was useful and mixed. A correct song appeared in the acoustic evidence for 11 of 12 performances. The runtime emitted the correct current song at least once for 10 of 12. It emitted 13 locks in total, including three false switches, and missed two songs.
 
-On August 13, Goose played in San Diego. SetScope listened while the show was happening and emitted correct blind song identities from audio that had not existed when the system was built.
+Set 1 had a 66-second capture-timebase gap, so its exact latencies were invalid. Set 2 passed input accounting, but its song boundaries were reconstructed from published whole-minute durations. The surviving audit does not establish what was rendered in the UI or delivered through the publication path.
 
-This was the smallest prospective test we had wanted from the beginning: can the runtime emit correct blind song identities during a genuinely new show?
+This was genuine prospective evidence that SetScope could recognize songs from a new show. It was not a formal whole-show reliability result. It showed the model could find most of the songs, and also that the controller could mistake a section of a long jam for another song, delay a correct transition for minutes, or retain the wrong state and never emit an acoustically recognized encore.
 
-It could.
-
-The [saved run and operator record](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0521-2026-08-13-live-show-audit.md) preserve the live trace. The later run ledger records that source date and setlist context were not used. We did not preserve one canonical pre-music receipt containing every candidate hash, audio route, mode, publication state, and start field later required by the full protocol.
-
-The runtime also missed performances and changed songs incorrectly. One set failed the capture-timebase check, and we lacked separate receipts for what reached the interface or public chat. The run did not supply a formal whole-show accuracy estimate or proof of viewer-visible delivery.
-
-The next question was how to let an autonomous research program keep improving those pieces without allowing one useful field test, one large engineering replay, or one polished percentage to become a claim it could not support.
+The browser tests changed what counted as progress. Offline evaluation could test recognition under controlled inputs. Browser and live runs tested whether the product received valid audio, remained quiet when it should, held the right state, changed at the right time, and delivered the result. SetScope needed both. A percentage from either one could not stand in for the other.

--- a/_posts/2026-08-30-a-discovery-loop-that-can-say-no.markdown
+++ b/_posts/2026-08-30-a-discovery-loop-that-can-say-no.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "A Discovery Loop That Can Say No"
-subtitle: "Bound the agent, preserve the failures, and let the evidence limit the claim."
+subtitle: "A strong result should authorize only the next step its evidence can support."
 date: 2026-08-30 08:00:00 -0400
 group: ai
 series: lab
@@ -11,138 +11,76 @@ permalink: /series/the-machine-in-the-lab/what-we-built-instead/
 categories: ai research zabriskie agents
 ---
 
-SetScope began as a viewer-facing song guesser: listen to a live Goose stream and identify the current song without receiving the date or setlist. The audio corpus pulled the project into a harder detour about measuring improvisation. Two notebooks from that detour were deleted after hidden setup decisions invalidated them.
+The best SetScope result so far arrived on 75 historical Goose shows we had set aside for engineering.
 
-The first research-discipline document was our response. It had ten rules, named roles, explicit approvals, and an advisor agent with authority to block work. We used it for Dispatch 002, an experiment that compared listener-marked returns to composition with an acoustic changepoint detector. Every required gate passed. The general interpretation was still unsupported.
+By ninety seconds of music, the new controller had identified the opening song correctly on 65 shows and made no wrong opening call. It initially stayed quiet on the other ten, kept listening, and eventually recovered the correct current song on all ten.
 
-The failure was useful because it changed what I thought the system needed to control. A long prompt could tell an agent to be careful. A checklist could require it to produce more artifacts. Neither represented the state of the research strongly enough to determine which action was allowed next.
+I could have summarized that as 100 percent across 75 shows. That would have hidden almost everything important about the result.
 
-The project needed a discovery loop that could say no.
+The first number was 65 correct decisions and ten abstentions, or 86.67 percent coverage at ninety seconds with no wrong calls. The later recoveries happened under a different rule and at different times. More importantly, the controller had been designed by inspecting earlier failures on these same 75 shows. The result was strong evidence that the engineering change worked on the material that shaped it. It was not independent evidence about what would happen next.
 
-## The loop is the system
+The project had another 38 shows that remained unopened. We did not run them. Setlist posting remained off. The result authorized one action: install the controller and take it back through the browser.
 
-This project used an autonomous research program to improve SetScope. The program could propose an experiment, implement it, run it, evaluate the output, and choose what to try next with limited human intervention. That is the same basic ambition behind the emerging work on automated discovery loops in science and engineering. The important unit is no longer one prompt or model response. It is the loop that carries state from one iteration into the next.
+That decision is what I mean by a discovery loop that can say no. The name deliberately echoes the company described in Part 1: the ambition is the same kind of automated experimental cycle, applied here to a much smaller problem. There is no affiliation between the projects.
 
-That state includes more than code and results. It includes which labels have been seen, which thresholds were adjusted, which failures changed the design, what the evaluator actually measured, which runtime path was exercised, and what claim the project is now tempted to make.
+## Why the loop needed a boundary
 
-The lost notebooks showed that information roles and methodological decisions had to survive across iterations. Dispatch 002 showed that an internally consistent evaluator could still measure the wrong thing. The browser incident showed that a correct offline experiment did not exercise the deployed audio path. In every case, an agent could produce a locally correct next step from a globally invalid state.
+SetScope listens to a live Goose stream and guesses which song is playing. I used an LLM agent to improve it: propose an experiment, write the code, run it, inspect the output, and use the result to choose what to try next.
 
-The correction was to move the critical state outside the model's conversational memory and make it durable.
+That loop made a solo project possible at a scale I could not have reached by hand. It also produced the failures in this series.
 
-## From instructions to state
+The first research notebook expanded into too many questions without preserving evidence capable of independently evaluating the path it took. The second wrote down a rule against fixed ninety-second jam boundaries, then reintroduced the same boundaries in its implementation. We responded with written plans and additional reviewers. The next Phish experiment passed its publication gates, but no prepublication review compared what was audible at both the listener and detector timestamps.
 
-An instruction such as "do not use the test set" sounds clear until the project has five copies of a performance, three feature caches, a threshold selected after an opened result, and an agent that did not participate in the original decision. The instruction has to become data the system can inspect.
+Each failure followed the same acceleration. The agent made a plausible choice, generated a result from it, and carried the result into the next experiment before the choice returned to view.
 
-The current process represents at least these things explicitly:
+More instructions inside the conversation did not solve that problem. The important state had to survive across agents and sessions: which shows had been opened, which failures had influenced the controller, which version actually ran, and what the resulting evidence was still allowed to support.
 
-- a question and the exact claim it is capable of supporting;
-- the role of every input population;
-- a candidate model, feature set, catalog, and policy identified by hashes;
-- an analysis and scoring specification frozen before outcomes are visible;
-- the boundary between prediction, scoring, diagnosis, and promotion;
-- immutable result artifacts, including invalid and negative outcomes;
-- the evidence scope of a run, from component crop to live runtime to observed UI or publication; and
-- the actions the system is permitted to take automatically.
+## What we built
 
-This is less elegant than telling an agent to "follow scientific best practices." It is also inspectable. A candidate cannot quietly change after the run starts if the installed artifact has a recorded digest. A shadow event cannot become a delivered chat post if publication is disabled and receipts are required. A show used for diagnosis cannot later be described as sealed confirmation without contradicting its recorded role.
+There is no single research-control application enforcing all of this. The current system is a workflow made from written plans, hashes, separate execution and scoring scripts, saved results, human approvals, and promotion rules.
 
-The rules still depend on people honoring them. State does not eliminate discretion. It makes the exercise of discretion visible.
+Three changes matter most.
 
-## A bounded experiment
+Every show has a recorded job. Some fit the acoustic models. Opened shows are available for debugging and comparison. A smaller group remains hidden for one final run. Once a result from a show changes the system, a new filename or branch cannot make that show independent again.
 
-The useful unit of autonomy became a bounded experiment rather than an open-ended request to improve the model.
+Each experiment freezes the version, inputs, controller policy, and scoring rule before execution. Predictions are saved before labels are joined. Failed capture, an abstention, and a negative result remain in the record instead of disappearing behind the next successful run.
 
-Before execution, the experiment records:
+Finally, the plan says what a result may change. A classifier score can justify integration work. An offline whole-show replay can justify a browser rehearsal. A browser rehearsal can justify a shadow run with a live stream. None of those steps automatically enables public setlist posting.
 
-1. the question;
-2. the allowed inputs;
-3. the candidate and every configurable policy;
-4. the metric and selection rule;
-5. the compute or iteration budget;
-6. the outcome that would falsify or stop the treatment; and
-7. the downstream action the result may authorize.
+People and agents still have to honor the process. Its value is that the next action can be checked against a durable record instead of reconstructed from chat history.
 
-Planning, execution, and scoring are separate states. The planner can inspect opened engineering evidence. The executor receives frozen inputs and does not change the candidate. The scorer joins outcomes only after immutable predictions exist. Promotion requires evidence appropriate to the claim being promoted.
+## The live show that became engineering data
 
-This last point is where many agent workflows become vague. A result may authorize one action without supporting the next. A replay on 75 opened shows can justify another browser rehearsal while remaining useless as independent confirmation. A prospective run may demonstrate correct identities on future audio without supplying the capture record needed for a whole-show latency metric. Controller, interface, and publication events require their own evidence. Each promotion crosses another boundary.
+The August 13 Goose show in San Diego supplied the first genuinely prospective evidence. Its audio did not exist while SetScope was being built. During the show, the runtime emitted the correct current song at least once for 10 of 12 performances. A correct title appeared in the internal acoustic evidence for 11 of 12.
 
-## Five coordinates for evidence
+It also emitted three false switches and missed two songs. Set 1 failed its capture-timebase check, which invalidated exact latency from that portion. The truth boundaries available after the show were approximate. The surviving audit does not establish what was rendered in the UI or delivered through the publication path.
 
-We eventually began classifying evidence on separate axes instead of assigning it one adjective such as "clean" or "live."
+The show answered the smallest product question: SetScope could produce useful blind song identifications from new live audio. It also showed exactly where the product was weak. The controller could mistake a long jam for another song, wait minutes before accepting a correct transition, and remain stuck on the wrong title after the acoustic models recovered.
 
-**Information access.** Was the outcome unavailable when the candidate was frozen, sealed until scoring, or already opened and available for adaptation?
+Once we inspected those failures and used them to design later versions, August 13 became engineering data. It could teach the agent what to fix. A later controller needed different evidence to show that the fix generalized.
 
-**Temporal relation.** Was the evaluation retrospective on existing audio or prospective on a future event?
+## What happened on the 75 shows
 
-**System scope.** Did it exercise an isolated model, an integrated offline replay, the live runtime through controller state, the rendered interface, or an outward publication path?
+The larger controller experiment began with 113 eligible, verified shows from 2021 through 2025. A frozen hash split assigned 75 to engineering and 38 to final confirmation before song titles or outcomes were examined.
 
-**Publication action.** Was the system operating in shadow mode, attempting a post, receiving an acknowledgment, or independently observed as visible?
+The agent used the 75 opened shows to develop how SetScope handled uncertainty. The selected version, 0532, began conservatively: 65 correct opening locks by ninety music seconds and ten abstentions. It made no premusic opening or recovery locks and no opening or recovery calls on material outside its song vocabulary.
 
-**Metric eligibility.** Did capture, truth, timing, and protocol requirements pass for the metric being reported?
+While the displayed state remained unknown, the controller continued to evaluate two independent model families. It recovered six ordinary Goose openers after collecting more evidence. Four other shows began with soundcheck jams or songs outside the catalog; the controller waited until it had sustained evidence for a known song actually being played. All ten recoveries matched the current in-catalog song.
 
-These coordinates prevent one strong property from standing in for the others. The August 13 run was prospective and its audio was unavailable when the candidate was built. It exercised the live path through saved controller outputs. It did not preserve complete proof of every frozen pre-music condition, its first set failed the timebase rule, its truth boundaries were reconstructed after the show, and no separate UI-observation or outward-publication receipt survives.
+The same replay produced 99.33 percent correct current-song choices among the switches whose truth could be scored. That number is useful for comparing engineering versions. It does not include Chrome, the macOS audio route, the interface, or public posting.
 
-So it establishes a valuable fact: the system emitted correct blind song identities during a genuinely new show. It does not establish a formal whole-show accuracy rate or successful automatic publication.
+The [saved result](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0532-continuous-unknown-recovery-result.md) names the only promotion it earned: package that exact controller into SetScope with posting disabled, then run a controlled browser rehearsal.
 
-That sentence is more cumbersome than "the live test passed." It is also much harder for the next agent to misunderstand.
+We packaged the controller with posting disabled. The browser rehearsal remained the next test, and the 38 final shows stayed closed.
 
-## Preserving failure as an output
+## The evidence we have not spent
 
-The project originally treated failed runs as interruptions on the way to the result. That made it easy to rerun something slightly differently and report only the version that completed.
+The unopened shows are useful because the controller has not learned from their outcomes. Before they can be scored, the local model artifacts, catalog, controller, inputs, and scoring script have to be frozen. Once the results are visible, those shows become ordinary engineering material for every later version influenced by them.
 
-Now invalidation is a terminal result. A capture with missing samples retains its events but cannot contribute to metrics requiring continuous time. A candidate that emits no lock remains in the coverage denominator. An unknown song is not silently removed because the closed catalog could not name it. A planned comparison that lacks synchronized clocks is reported as missing rather than assigned a tie.
+A good result there would answer one offline whole-show question for one fixed version. The browser would still need to prove that it received continuous audio. The interface and publication path would still need their own receipts.
 
-Negative experiments remain useful too. One rebuilt question searched 263 curated jamchart entries for a frozen set of descriptive terms, found none, and halted before loading audio. Preserving the halt prevented the agent from silently broadening the phrase list until something matched.
+This is expensive in a small project. Every hidden show is one less show available for diagnosis. The alternative is a test set that quietly becomes a development set while its headline stays unchanged.
 
-A protocol that produces only impeccable refusals is not a research program. The halt matters because it keeps an unobserved change from turning a failed question into an apparently successful one.
+The workflow does not guarantee good science. A frozen experiment can still measure the wrong thing, and approvals can decay into ceremony. What it gives the autonomous program is a memory it cannot rewrite without leaving evidence: which inputs were available, what failed, which version ran, and where the result had to stop.
 
-## The larger opened engineering result
-
-After the August 13 show, we used opened shows to improve the temporal controller and its handling of abstention. The [corpus protocol](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0494-corpus-scale-evaluation-preregistered.md) had identified 113 eligible, manifest-verified shows from 2021 through 2025 whose dates appeared in neither fitting nor prior evaluation. A frozen within-year hash split assigned 75 to engineering and 38 to sealed confirmation without reading song titles or outcomes.
-
-The selected controller candidate, version 0532, was designed after reviewing earlier failures, including the August 13 show and version 0531. The 75 shows were opened development material. The result explicitly classified itself as engineering evidence and disabled setlist writes. The replay did not exercise Chrome, CoreAudio, the interface, or public posting, and it was not independent confirmation.
-
-Under the frozen replay rule, the selected treatment produced 65 correct initial locks by ninety admitted music seconds and abstained on the remaining ten shows. It emitted no wrong initial locks, which yields 100 percent selective initial precision and 86.67 percent correct coverage across all 75 shows. Median admitted music time to a correct initial lock was sixty seconds. It produced no premusic locks and no initial or recovery locks on out-of-vocabulary material in that replay.
-
-The [complete replay result](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0532-continuous-unknown-recovery-result.md) also retained the observation-level accounting:
-
-| Observation class | Count |
-| --- | ---: |
-| All ten-second observations | 65,085 |
-| Scoreable in-catalog observations | 61,446 |
-| Correct state | 57,079 |
-| Incorrect state | 3,415 |
-| Unlocked | 952 |
-| Outside the scoreable population | 3,639 |
-
-That is 92.89 percent correct state across scoreable observation time. Across 733 eligible in-vocabulary archive boundaries, the system detected 632 by ninety admitted music seconds, or 86.22 percent. Different slices of the replay produce different transition rates, which is precisely why the artifact retains the raw counts and scoring scope rather than one summary percentage.
-
-The larger sample does not replace the prospective field test. It answers a different question: under a frozen replay rule on these opened shows, did this treatment meet the engineering gates required to advance? It did, and the authorized next action is another complete-product test, not a universal reliability claim.
-
-## The boundary the agent cannot cross
-
-The other 38 shows from the same eligible population remain sealed under a [one-time final-candidate protocol](https://github.com/cmeiklejohn/zabriskie/blob/f52b45f47e0884d1504474d276e4230e2e0f2acd/tools/audio_detection/cloud/v0512-sealed-confirmation-execution-protocol.md). The within-year hash assignment prevents outcome- or song-based selection and preserves the year distribution; it does not make the 38 shows representative of every venue, source, year, or song in the wider Goose archive. The candidate, model artifacts, catalog, policy, inputs, scorer, and hashes must be frozen before that population is opened. Once scored, the set becomes opened forever for that candidate lineage.
-
-This is intentionally expensive. The point of a sealed evaluation is not to create a renewable source of encouraging numbers. It is to answer one question once without allowing the answer to influence the system that produced it.
-
-Even a good sealed result would remain one level in the product record. It could establish independent performance on the frozen catalog evaluation without showing that the browser path, interface, or automatic-publication path worked. Evidence at one level may authorize the next test without establishing the levels above it. Keeping those steps separate is the central job of the control plane.
-
-## What we built instead
-
-I do not think the resulting process is a universal method for AI-assisted research. It grew around specific failures in one self-directed project, and it has costs we have not measured.
-
-The gates may consume enough attention to erase the speedup. They can become paperwork. Approvals can become ceremonial. A protocol can preserve a perfect record of a bad measurement. We do not yet have an opportunity ledger showing how often each control catches a problem versus merely delaying work.
-
-What the system can do is narrower:
-
-- make data roles and openings durable;
-- freeze a bounded experiment before outcomes arrive;
-- require an evaluator with access to evidence outside the generated artifact chain;
-- exercise the path the product will actually run;
-- preserve invalid and negative outcomes;
-- attach every result to the claims and actions it may support; and
-- block automatic promotion when the required evidence does not exist.
-
-That is enough to change the behavior of the loop. The agent can still propose the next experiment and implement most of it. It can no longer convert a promising chart into a sealed result, an internal state into a delivered product event, or a successful engineering replay into authorization to post publicly without leaving a contradiction in the record.
-
-The method will be tested by inconvenience, not prose. Goose is playing eleven shows from August 13 through August 28. SetScope will change during the run. Streams will fail, songs will segue, and new covers may fall outside the catalog. The record has to retain which version heard each show, including the nights when no valid result exists. That is where the protocol becomes real.
+The next browser rehearsal is the immediate test. It has to preserve the abstention and recovery behavior while adding Chrome, CoreAudio, the controller, and the rendered state back into the path. If that works, the 38 shows will still be waiting for one final offline question. If it does not, they stay closed while the failure becomes the next engineering case.

--- a/series/the-machine-in-the-lab.md
+++ b/series/the-machine-in-the-lab.md
@@ -11,11 +11,11 @@ image_card_type: summary_large_image
 <p class="series-landing-lead">I wanted to build a tool that could tell Goose fans what song they were hearing while a show was still happening. I also wanted an autonomous LLM system to do the research needed to build it. The system would propose experiments, write and run code, evaluate the results, and decide what to try next. The tool became SetScope.</p>
 
 <p class="series-landing-meta">
-  By my estimate, the agent compressed weeks of implementation into hours. It also helped produce two polished research notebooks that I later discarded. One leaked recordings between training and test. The other analyzed the wrong portions of the songs because it inherited a 90-second segmentation rule that contradicted the method I had written. Both came with clean code, persuasive charts, and conclusions that sounded finished.
+  By my estimate, the agent compressed weeks of implementation into hours. It also helped produce two polished research notebooks that I later discarded. The first expanded across song recognition and improvisation research until its central public claim failed held-out validation and the notebook no longer had independent evidence for the path it had taken. The second explicitly rejected a 90-second segmentation rule, then reused that rule in its first implementation. Both came with clean code, persuasive charts, and conclusions that sounded finished.
 </p>
 
 <p class="series-landing-meta">
-  I have a PhD and years of systems-research experience. These were not rules I did not know to write: both methods stated constraints the system later violated. I worked from the reports because an autonomous researcher that must be manually reconstructed after every run is not autonomous. The project began with automatic song and set detection. The recordings pulled it into harder questions about improvisation. After both notebooks failed, I returned to the original goal: build the live song guesser.
+  I have a PhD and years of systems-research experience. The problem was not that I had never heard of a holdout or did not understand that a measurement must match its method. I worked from the reports because an autonomous researcher that must be manually reconstructed after every run is not autonomous. The project began with automatic song and set detection. The recordings pulled it into harder questions about improvisation. After both notebooks failed, I returned to the original goal: build the live song guesser.
 </p>
 
 <p class="series-landing-meta">


### PR DESCRIPTION
## Summary
- rewrite Parts 4-6 around their source-backed incident chronologies
- keep all three posts explicitly unpublished pending author review
- remove stale notebook claims from the series landing page and synchronize teaser subtitles
- tighten Parts 1 and 2 after a final whole-series read

## Review record
- independent evidence audits for Parts 4, 5, and 6
- repository voice-guide pass
- final hostile continuous read across Parts 1-6
- every identified publication blocker corrected and rechecked

## Verification
- full Jekyll build with future and unpublished posts
- local browser renders for Parts 4-6
- `git diff --check`

Part 7 remains an unpublished results scaffold and is not included.