### PR TITLE
Label series posts in the homepage list

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -468,6 +468,29 @@ ul.posts li:last-child {
   text-underline-offset: 3px;
 }
 
+.home-post-entry {
+  min-width: 0;
+}
+
+.home-post-series {
+  font-family: var(--font-ui);
+  font-size: 0.82rem;
+  font-weight: 400;
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+
+.home-post-series:hover {
+  color: var(--link-hover);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.home-post-series-sep {
+  color: var(--fg-muted);
+  margin-right: 0.25rem;
+}
+
 @media (max-width: 520px) {
   ul.posts li {
     grid-template-columns: 1fr;

--- a/index.html
+++ b/index.html
@@ -29,9 +29,19 @@ description: "Christopher Meiklejohn — Ph.D., Software Engineering (CMU). Note
     <h2 id="home-recent-heading" class="home-section-title archive-section-heading">Recent</h2>
     <p class="archive-section-intro">The latest writing on the site. Open the archive for full lists by topic.</p>
     <ul class="posts">
-      {% assign recent_posts = site.posts | where_exp: "p", "p.series != 'mas'" %}
-      {% for post in recent_posts limit:9 %}
-        <li><span class="home-post-date">{{ post.date | date_to_string }}</span> <a class="home-post-link" href="{{ post.url }}">{{ post.title }}</a></li>
+      {% for post in site.posts limit:15 %}
+        {% assign series_meta = site.data.series[post.series] %}
+        {% assign series_title_prefix = "" %}
+        <li>
+          <span class="home-post-date">{{ post.date | date_to_string }}</span>
+          <span class="home-post-entry">
+            {% if series_meta %}
+              {% capture series_title_prefix %}{{ series_meta.title }}, {% endcapture %}
+              <a class="home-post-series" href="{{ series_meta.landing_url }}">{{ series_meta.title }}</a><span class="home-post-series-sep" aria-hidden="true">·</span>
+            {% endif %}
+            <a class="home-post-link" href="{{ post.url }}">{{ post.title | remove_first: series_title_prefix }}</a>
+          </span>
+        </li>
       {% endfor %}
     </ul>
   </section>


### PR DESCRIPTION
## Summary
- expand the homepage recent list from 9 to 15 posts
- include multi-agent series posts instead of filtering them out
- prefix series posts with a linked series name
- avoid repeating series names already embedded in older post titles

## Verification
- Jekyll production build passes
- confirmed 15 rendered recent rows
- checked desktop and mobile layouts
- confirmed Parts 3 through 6 of The Machine in the Lab remain unpublished