### PR TITLE
Italicize homepage series labels

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -475,6 +475,7 @@ ul.posts li:last-child {
 .home-post-series {
   font-family: var(--font-ui);
   font-size: 0.82rem;
+  font-style: italic;
   font-weight: 400;
   color: var(--fg-muted);
   text-decoration: none;


### PR DESCRIPTION
## Summary
- italicize series names in the homepage recent-post list
- preserve the existing size, color, links, and responsive layout

## Verification
- Jekyll production build passes
- checked desktop and mobile renders