### PR TITLE
Match homepage series colon styling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -479,17 +479,13 @@ ul.posts li:last-child {
   font-weight: 400;
   color: var(--fg-muted);
   text-decoration: none;
+  margin-right: 0.25rem;
 }
 
 .home-post-series:hover {
   color: var(--link-hover);
   text-decoration: underline;
   text-underline-offset: 3px;
-}
-
-.home-post-series-sep {
-  color: var(--fg-muted);
-  margin-right: 0.25rem;
 }
 
 @media (max-width: 520px) {

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@ description: "Christopher Meiklejohn — Ph.D., Software Engineering (CMU). Note
                 {% capture series_title_prefix %}{{ series_meta.title }}, {% endcapture %}
                 {% assign display_title = post.title | remove_first: series_title_prefix %}
               {% endif %}
-              <a class="home-post-series" href="{{ series_meta.landing_url }}">{{ series_meta.title }}</a><span class="home-post-series-sep" aria-hidden="true">:</span>
+              <a class="home-post-series" href="{{ series_meta.landing_url }}">{{ series_meta.title }}:</a>
             {% endif %}
             <a class="home-post-link" href="{{ post.url }}">{{ display_title }}</a>
           </span>


### PR DESCRIPTION
## Summary
- include the colon inside the italic series link
- remove the separate mismatched separator element and styling

## Verification
- Jekyll production build passes
- confirmed the colon inherits the exact series-label typography