### PR TITLE
Tighten the Part 2 research detour

### DIFF
--- a/_data/lab_series.yml
+++ b/_data/lab_series.yml
@@ -75,7 +75,7 @@
     - title: "The split that was not separate"
       detail: "Open with the concrete pair-level leak: the same performance could appear in a training pair and a test pair even though the rows were different. Establish immediately that a written separation rule did not control the code."
     - title: "The audio-research project"
-      detail: "Preserve the complete chronology for a standalone reader: automatic set detection was the original goal; the corpus and apparent power of audio features pulled the project into the Type I/Type II improvisation detour where the two notebooks failed; SetScope later returned to the original target. Establish the author's research background, corpus, labels, and why an LLM agent made work at this scale possible. Treat the PhD as evidence that the constraints were understood and explicit, while making clear that expertise cannot reveal a violation the autonomous system neither blocks nor reports."
+      detail: "Preserve the complete chronology for a standalone reader: automatic set detection was the original goal; promising early results pulled the autonomous program into an improvisation detour where the two notebooks failed; SetScope later returned to the original target. Establish why an LLM agent made work at this scale possible while making clear that expertise cannot reveal a violation the autonomous system neither blocks nor reports."
     - title: "Notebook 1"
       detail: "Reconstruct the pair-level cross-validation leak and the later 44-case detector holdout, including the 38 analyzable cases and the fixed ninety-second region assumption. Show why a late detector audit could reject that result but could not independently replay the notebook's adaptive path."
     - title: "Notebook 2"

--- a/_drafts/the-machine-in-the-lab-series-architecture.md
+++ b/_drafts/the-machine-in-the-lab-series-architecture.md
@@ -284,7 +284,7 @@ The post should concede all three without accepting the premise that autonomy re
 
 ### Standalone context requirement
 
-Part 2 must explain the full origin-detour-return chronology, audio question, corpus, and labels in plain language. A standalone reader must learn that automatic set detection was the original goal before the corpus pulled the project into Type I and Type II jam research. The post cannot assume the reader understands those categories or has read Part 1.
+Part 2 must explain the full origin-detour-return chronology in plain language. A standalone reader must learn that automatic set detection was the original goal before promising intermediate results pulled the autonomous program into improvisation research. The post cannot assume the reader has read Part 1.
 
 ### Handoff to Part 3
 

--- a/_drafts/two-notebooks-lost-three-pass-audit.md
+++ b/_drafts/two-notebooks-lost-three-pass-audit.md
@@ -14,7 +14,7 @@ Four adversarial readers examined the post independently for standalone clarity,
 
 The previous post treated the pair-level training leak, the ninety-second detector, the reserved test data, and the incomplete purge as separate notebook anecdotes. Its central sentence said that a missing rule could propagate through later work, but the notebook sections did not build that argument.
 
-The first rewrite made enforcement the throughline: a rule written in a plan or data file is not a safeguard unless it controls execution or stops the process when violated. The Goose-to-Phish pivot remained only to explain why the project changed corpora and questions.
+The first rewrite made enforcement the throughline: a rule written in a plan or data file is not a safeguard unless it controls execution or stops the process when violated. The pivot from song identification to improvisation remained only to explain how promising intermediate results changed the question the autonomous program pursued.
 
 The pass failed. It repeated the thesis too often, placed two unrelated failures under one section heading, and claimed that leftover Notebook 1 cache data caused Notebook 2 to reuse the ninety-second segmentation.
 
@@ -40,7 +40,9 @@ The post no longer treats the cache as the cause of Notebook 2's recurrence or c
 
 The final pass removed remaining research shorthand, defined a notebook and the autonomous division of labor, explained the A/B–A/C pair leak, defined the three data roles in plain language, and replaced technical cache terminology with a description of generated measurements stored outside the project folder.
 
-The structural reader confirmed one continuous sequence: concrete leak; autonomous-process definition; SetScope origin; labeled-data detour to Phish; Notebook 1 failures; Notebook 2 recurrence; later purge failure; executable safeguards; return to SetScope.
+The structural reader confirmed one continuous sequence: concrete leak; autonomous-process definition; SetScope origin; detour into improvisation; Notebook 1 failures; Notebook 2 recurrence; later purge failure; executable safeguards; return to SetScope.
+
+The author read then removed an unnecessary explanation of how the source data changed. The post now keeps only the causal point that matters to its argument: apparent progress made by the autonomous program kept the improvisation detour running.
 
 The evidence reader required two last corrections: the detector treated changes within composed passages as evidence rather than directly labeling passages, and later analyses reused generated measurements rather than generated audio clips. Both were corrected.
 

--- a/_posts/2026-08-18-two-notebooks-lost.markdown
+++ b/_posts/2026-08-18-two-notebooks-lost.markdown
@@ -24,9 +24,7 @@ The LLM wasn't just writing code that I reviewed step by step. I supplied the ob
 
 The original objective was to build [SetScope]({% post_url 2026-08-15-science-at-llm-speed %}#the-research-loop-gets-faster), a system that could listen to a live [Goose](https://www.goosetheband.com) show and name the song while the band was still playing it. A live version can change in speed, length, arrangement, and improvisation while remaining recognizably the same song.
 
-Early comparisons appeared to show that composed passages carried much of a song's recurring identity while improvised passages accounted for much of the variation. That opened a more interesting question: could measurements of rhythm, harmony, and texture describe how performances diverged during improvisation?
-
-Answering it required labeled data. My Goose archive contained recordings and song titles, but not a large collection of annotations identifying performances with open-ended jams. [Phish](https://phish.com/) had decades of performances accompanied by [community-maintained jam annotations](https://phish.net/blog/1387398339/new-and-improved-phish-jam-charts.html). The available data pulled the research away from the Goose product and toward Phish. The reports arrived quickly and appeared to form a coherent account of the music, so I let the program continue.
+The first song-identification experiments produced a positive result: measurements from the composed sections appeared to distinguish one song from another across live performances. That suggested the composed parts preserved much of a song's identity while the improvised parts accounted for much of the variation between performances. So the program started asking what those same measurements could tell us about the improvisation. Its reports arrived quickly and appeared to form a coherent account of the music, so I let it continue. That detour became Notebook 1.
 
 ## Notebook 1
 
@@ -40,7 +38,7 @@ That audit rejected this detector. It did not provide a clean test of the entire
 
 ## Notebook 2
 
-Notebook 2 began on April 30 with a written methodology intended to prevent the first notebook's failures. It assigned each song permanently to one of three uses: trying methods, choosing among them, or one final test that was supposed to remain unopened until the method was finished. It also rejected the blanket ninety-second division in favor of boundaries chosen for each song from the music itself.
+Notebook 2 continued the improvisation work under a written methodology intended to prevent the first notebook's failures. It began on April 30 and assigned each song permanently to one of three uses: trying methods, choosing among them, or one final test that was supposed to remain unopened until the method was finished. It also rejected the blanket ninety-second division in favor of boundaries chosen for each song from the music itself.
 
 The code didn't follow those rules. The first implementation again set the opening and closing regions to ninety seconds. Later analyses reused measurements cut at those boundaries. The method had warned against the assumption, but nothing compared the running code with the method and stopped the work.
 
@@ -62,4 +60,4 @@ Those checks belong inside the autonomous process. My job is to define and appro
 
 A natural-language instruction can describe a safeguard. It cannot enforce one.
 
-After Notebook 2, I returned the program to SetScope's original Goose song-identification problem. A new live show offered evidence that no earlier notebook could have seen. But each show could be new only once. Once the program used that show to decide what to do next, was it still independent evidence or had it become part of development? That's the question in Part 3. Part 4 returns to the separate problem exposed by the ninety-second detector: whether a consistent measurement actually represents the music named in the claim.
+After Notebook 2, I set the improvisation work aside and returned the program to SetScope's original Goose song-identification problem. A new live show offered evidence that no earlier notebook could have seen. But each show could be new only once. Once the program used that show to decide what to do next, was it still independent evidence or had it become part of development? That's the question in Part 3. Part 4 returns to the separate problem exposed by the ninety-second detector: whether a consistent measurement actually represents the music named in the claim.


### PR DESCRIPTION
## Summary
- remove the unused Phish and labeled-data subplot from Part 2
- connect the improvisation detour directly to the positive song-identification result
- align the series outline and editorial record with the article's actual argument

## Verification
- BUNDLE_PATH=/Users/cmeiklejohn/GitHub/cmeiklejohn.github.io/vendor/bundle bundle exec jekyll build
- git diff --check