### PR TITLE
Smooth Every Card Will Show section transition

### DIFF
--- a/_drafts/every-card-will-show-three-pass-audit.md
+++ b/_drafts/every-card-will-show-three-pass-audit.md
@@ -5,7 +5,7 @@ Post: `_posts/2026-08-24-every-card-will-show.markdown`
 Evidence base:
 
 - Zabriskie `origin/main` at `fffec3548949bce7803dd48ad8600de9ca6e228d`.
-- Blog `origin/master` at `788b3154f524af52c66ec33694d200e9da027459`.
+- Blog `origin/master` at `c5ee2c29d7e4bb8dfa497979ca0ee572043274b7`.
 - The author's first-person account for the conversation, elapsed time, the agent's 47-item product enumeration with 20 missing, agency, repeated requirement, production timing, and Zabriskie's role as a fully vibe-coded application whose implementation code he does not read.
 
 ## Structural reader
@@ -100,6 +100,7 @@ Corrections preserved from the evidence pass:
 - Read the revised page continuously after rendering. Removed the repeated Hero explanation, narrowed every conclusion that had called the two selected histories `extremes`, and retained the short sentence `Lean correctly proved coverage for an itinerary no person could take` as the central turn.
 - Rechecked the code-block spacing and the new third-level headings in the rendered page; both have clear separation from adjacent prose.
 - Added the vibe-coding paragraph between the product introduction and The Lot so the reader understands why the author evaluated browser behavior and requested audits instead of reading the implementation. The later conclusion now asks for the formal statement to be presented in terms a person can evaluate, rather than requiring manual source inspection.
+- Added a transition into the first implementation section: the request to distribute cards across the day became an unrequested policy about what each individual visit could omit.
 
 ## Remaining publication checks
 

--- a/_posts/2026-08-24-every-card-will-show.markdown
+++ b/_posts/2026-08-24-every-card-will-show.markdown
@@ -43,7 +43,7 @@ That responsibility doesn't make the intermediate decisions mine. I asked for on
 
 ## What the agent invented instead
 
-To shorten the page, the coding agent began adding limits without asking me what should be cut. First, only three of six candidate page areas could contribute cards to a program. Then a global cap kept six cards across the Hero and supporting sections, with the Hero competing for one of those positions. Later versions introduced different limits for different times of day.
+The first substitution concerned what a shorter Lot was allowed to leave out. I had asked for the cards to be distributed across the day. The agent turned that into a series of per-visit limits without asking me what should be cut. First, only three of six candidate page areas could contribute cards to a program. Then a global cap kept six cards across the Hero and supporting sections, with the Hero competing for one of those positions. Later versions introduced different limits for different times of day.
 
 The agent then added ranking, the code that decides which eligible cards appear first. Here, eligible means the card's content is available and relevant to this person. Deadlines received a 1,000-point advantage. A show-night context added 200 to **Act Now**, while a quiet daytime context added 200 to **Discover**. Attending a run of shows added 60 to **Your Couch Tour** and **Your Circle**. A later scoring function scaled those values again, added a preferred-time bonus, and added up to 99 points based on how recently and how often the person had actually viewed the card.
 


### PR DESCRIPTION
## Summary
- connect the requested day-wide distribution to the agent’s invented per-visit limits
- avoid opening the section as an abrupt implementation changelog

## Verification
- local Jekyll build
- rendered transition read in the local preview