### PR TITLE
Condense the invented policy section

### DIFF
--- a/_drafts/every-card-will-show-three-pass-audit.md
+++ b/_drafts/every-card-will-show-three-pass-audit.md
@@ -5,7 +5,7 @@ Post: `_posts/2026-08-24-every-card-will-show.markdown`
 Evidence base:
 
 - Zabriskie `origin/main` at `fffec3548949bce7803dd48ad8600de9ca6e228d`.
-- Blog `origin/master` at `e8db060c110c3850b107d5d4df854a7a6533eb8a`.
+- Blog `origin/master` at `7f9955e0a2594bc2fc9318ad3c340df89eed2f23`.
 - The author's first-person account for the conversation, elapsed time, the agent's 47-item product enumeration with 20 missing, agency, repeated requirement, production timing, and Zabriskie's role as a fully vibe-coded application whose implementation code he does not read.
 
 ## Structural reader
@@ -30,9 +30,9 @@ The new subheads keep the model failure, corrected same-day representation, hist
 | Roughly ten hours on August 22 and twelve on August 23 | Author recollection | Kept with `roughly` and changed relative dates before moving the post to August 24. |
 | 29 cards and more than 15,000 pixels | PR #2514 evidence records 29 cards and 15,554 pixels | Rounded pixel count in prose. |
 | Three of six candidate areas, then a six-card global cap | PRs #2505 and #2514 | Corrected to say that the Hero competed inside the six positions rather than sitting above six supporting positions. |
-| Ranking values 1,000, 200, 60, and up to 99 staleness points | Ranking implementations in the audited history | Corrected the contexts: show-night adds 200 to Act Now, quiet daytime adds 200 to Discover, and tour state adds 60 to Couch Tour and Circle. |
+| Ranking values 1,000, 200, 60, and up to 99 staleness points | Ranking implementations in the audited history | Removed the exact constants from the public post because they do not support a later claim. Retained the ranking inputs and the staleness definition needed by the reachability and Lean sections. |
 | Connections given a late preference and On This Day products reversed | Audited merged implementations and their corrections | Avoids presenting late affinity as an absolute gate; product judgment about its intended 11 PM home remains first-person interpretation. |
-| The capacities totaled 26, then 27 | PRs #2599 and #2610 | Kept with the distinction that this was arithmetic over incompatible states. |
+| The capacities totaled 26, then 27 | PRs #2599 and #2610 | Removed the intermediate total of 26. Kept 27 because the article uses it as the example of arithmetic over incompatible schedules. |
 | Weekday positions 20 then 21; weekend positions 15 then 16 | Derived from one visit to each distinct old program | Removed from the public post because the intermediate totals obscured the only distinction the argument needs: weekday and weekend followed mutually exclusive schedules. |
 | Audit and repository counts of 42, 46, and 45 | PRs #2602, #2621/#2622, and merged final catalog | The 42-card documentation audit was internally inconsistent. The first executable inventory contained 46 ranked identities. The later server-owned layout collapsed Local Scene from separate Act Now and Discover identities into one canonical Discover identity, producing the current 45. The repository does not preserve the remaining 47-to-46 explanation. |
 | The documentation audit promised coverage within a week | PR #2602 for the weekly claim; author account for the fact that no weekly window was requested | Identified as a hallucinated replacement of the stated one-day requirement, not merely a weaker interpretation. |
@@ -82,7 +82,7 @@ Corrections preserved from the evidence pass:
 - Reworked the opening for a reader who has never used Zabriskie: separate paragraphs now explain the app's cultural scope and non-follower organization, common activities, The Lot, cards, and the five daily programs before the incident begins. Added a link to the deeper live-show account in "The Whole Night."
 - Defined ranking, eligibility, staleness, the catalog, supporting positions, reachability testing, adversarial review, server and browser responsibilities, proof assistant, differential testing, and continuous integration at first use.
 - Kept the short paragraphs around the opening contradiction and the first incorrect Lean model because both are genuine turns.
-- Kept implementation constants in one compact paragraph so they establish the invented policy without turning the post into a changelog.
+- Removed scoring constants that never support a later claim. Kept the ranking inputs and defined staleness because both matter to the later reachability and history explanations.
 - Defined staleness and Lean on first use.
 - Reordered the Lean section so the first passing but wrong model appears before the repair.
 - Kept the Lean examples for typed card and visit data, the history transition, the coverage helpers, and the theorem, while explaining each in prose.
@@ -103,6 +103,7 @@ Corrections preserved from the evidence pass:
 - Added a transition into the first implementation section: the request to distribute cards across the day became an unrequested policy about what each individual visit could omit.
 - Made the reachability substitution explicit: one shared history covering all cards became a separate favorable history for each card. Combined the following explanation so the section states the contrast once.
 - Replaced the dense weekday/weekend capacity accounting with the two actual schedules and the direct explanation that 27 added mutually exclusive programs.
+- Condensed `What the agent invented instead` around four necessary points: caps, ranking and catalog policy, concrete classification failures and false owner attribution, and the impossible 27-position argument.
 
 ## Remaining publication checks
 

--- a/_posts/2026-08-24-every-card-will-show.markdown
+++ b/_posts/2026-08-24-every-card-will-show.markdown
@@ -43,39 +43,29 @@ That responsibility doesn't make the intermediate decisions mine. I asked for on
 
 ## What the agent invented instead
 
-The first substitution concerned what a shorter Lot was allowed to leave out. I had asked for the cards to be distributed across the day. The agent turned that into a series of per-visit limits without asking me what should be cut. First, only three of six candidate page areas could contribute cards to a program. Then a global cap kept six cards across the Hero and supporting sections, with the Hero competing for one of those positions. Later versions introduced different limits for different times of day.
+The first substitution concerned what a shorter Lot was allowed to leave out. I had asked for the cards to be distributed across the day. The agent turned that into per-visit limits: only three of six candidate page areas could contribute, then a six-card cap made the Hero compete with the supporting sections, and later versions gave different times of day different limits.
 
-The agent then added ranking, the code that decides which eligible cards appear first. Here, eligible means the card's content is available and relevant to this person. Deadlines received a 1,000-point advantage. A show-night context added 200 to **Act Now**, while a quiet daytime context added 200 to **Discover**. Attending a run of shows added 60 to **Your Couch Tour** and **Your Circle**. A later scoring function scaled those values again, added a preferred-time bonus, and added up to 99 points based on how recently and how often the person had actually viewed the card.
+The agent also wrote a ranking policy and a catalog of card identities. It assigned cards to sections, positions, and preferred times, then used deadlines, show-night context, tour status, and viewing history to decide which survived. The code called that last signal staleness and calculated it from how recently and how often a person had viewed the card. I hadn't asked for these product rules, and the agent didn't bring them back to me. They determined what people could see and what evidence would count as success.
 
-It also created a catalog, the list of cards known to the ranking system, which assigned every card an identity, section, deadline status, position within its section, and preferred time of day.
-
-I didn't request those limits, scores, preferred times, or classifications. I kept asking for one thing: take one person, have them visit the five actual programs during one calendar day, and show them every relevant card at least once.
-
-The agent never brought these choices back to me as product questions. It made them, encoded them in the product, and continued as though I had supplied them. An agent has to fill in implementation details, but these were not details. They changed what people could see, when they could see it, and what evidence would count as success.
-
-The distinction matters because a reasonable classification can still be wrong. **Connections**, a card about people whose taste overlaps with yours, was given a late-night preference. Around 11 PM became its intended home even though it could sometimes rotate into another program. That made little sense for something meant to begin a listen, read, or watch. Two **On This Day** products were wired backward in merged code, so the broader historical card and the personal-history card landed in each other's places.
+Some choices were plainly wrong. **Connections**, a card about people whose taste overlaps with yours, was given a late-night preference even though it was meant to begin a listen, read, or watch. Two **On This Day** products were wired backward, so the broader historical card and the personal-history card landed in each other's places.
 
 One comment even described a three-section rule as the "owner's cap decision." I had made no such decision. The agent had hallucinated where the policy came from: it invented a rule while implementing a different requirement, then attributed that rule to me. The invented decision began constraining later work as though I had chosen it.
 
-The most revealing number was 27. It sounded like a product limit, but it came from adding the capacities of five time-of-day states used by the code. Initially those limits totaled 26. When late night increased from three cards to four, they totaled 27.
-
-The problem was that those five states couldn't occur during one day.
-
-Before the repair, those five names did not mean five stops in a day. They described two different schedules:
+The clearest numerical argument was 27, presented as the number of card positions available across the day. It came from adding the capacities of five source-code states after the late-night limit increased. But those states described two different schedules, not five stops in one day:
 
 - A weekday could reach weekday morning, workday, evening, and late night.
 - A weekend could reach weekend daytime, evening, and late night.
 
-Evening and late night appeared on both schedules, but the other programs were mutually exclusive. The agent reached 27 by adding capacity from all five names anyway, as though one person could take both schedules on the same date.
+Evening and late night appeared on both schedules, but the other programs were mutually exclusive. Adding all five capacities treated one person as though they could take both schedules on the same date.
 
-Twenty-seven was therefore not evidence that one day had room for every card. It was arithmetic over an impossible itinerary.
+Twenty-seven was arithmetic over an impossible itinerary, not evidence that one day had room for every card.
 
 <figure style="max-width: 640px; margin: 2rem auto;">
   <img src="/img/zabriskie-every-card-will-show-coming-up.jpg" alt="The Coming Up card in the late-hours Lot, listing two Goose shows at Red Rocks and a Phish show at Dick's Sporting Goods Park" loading="lazy" style="width: 100%; height: auto; border-radius: 24px;">
   <figcaption>Farther down the late-hours program: Coming Up, with the next Goose and Phish dates. A single program is intentionally partial; the disputed guarantee concerns the five visits together.</figcaption>
 </figure>
 
-The capacity argument doesn't explain those 20 missing cards by itself. What the history does establish is that the argument didn't model the day I had repeatedly described.
+The number doesn't explain those 20 missing cards by itself. It establishes something narrower: the capacity argument didn't model the day I had repeatedly described.
 
 ## What the checks actually established
 


### PR DESCRIPTION
## Summary
- condense What the agent invented instead around the four facts used by the argument
- remove unused scoring constants and repeated policy statements
- preserve the staleness definition needed by later sections

## Verification
- local Jekyll build
- continuous rendered read of the condensed section