### PR TITLE
Correct the Lean same-day explanation

### DIFF
--- a/_drafts/every-card-will-show-three-pass-audit.md
+++ b/_drafts/every-card-will-show-three-pass-audit.md
@@ -5,7 +5,7 @@ Post: `_posts/2026-08-24-every-card-will-show.markdown`
 Evidence base:
 
 - Zabriskie `origin/main` at `fffec3548949bce7803dd48ad8600de9ca6e228d`.
-- Blog `origin/master` at `a0882c97da9c2e0bb5a7146a483bac63769d3288`.
+- Blog `origin/master` at `d7e97bb52ec72c8eaba51dfff1f2cbb8370d5db3`.
 - The author's first-person account for the conversation, elapsed time, the agent's 47-item product enumeration with 20 missing, agency, repeated requirement, production timing, and Zabriskie's role as a fully vibe-coded application whose implementation code he does not read.
 
 ## Structural reader
@@ -56,6 +56,7 @@ The new subheads keep the model failure, corrected same-day representation, hist
 
 Corrections preserved from the evidence pass:
 
+- Corrected the same-day explanation: `fiveVisitsOn` reuses one `localDay` by construction; Lean is not performing a separate inequality check over the five records.
 - Replaced any implication that 27 caused the observed 20 missing cards with two independently bounded claims.
 - Replaced "daily maximum" language with "one visit to each distinct program."
 - Corrected the old six-card cap and 20/21 and 15/16 totals to include the Hero.

--- a/_posts/2026-08-24-every-card-will-show.markdown
+++ b/_posts/2026-08-24-every-card-will-show.markdown
@@ -121,7 +121,7 @@ def fiveVisitsOn (localDay : Nat) : List LocalVisit :=
   ]
 ```
 
-All five records carry the same `localDay`, and Lean checks that none differs. Its own hour-to-program function uses the five fixed hours rather than interpreting the date. Separate Go tests therefore send the same hours through the production clock resolver on both a Wednesday and a Sunday. Those cases guard against a return of the old weekday-versus-weekend split.
+`fiveVisitsOn` takes one `localDay` argument and copies it into all five records, so they share a day by construction. Its hour-to-program function uses the five fixed hours rather than interpreting the date. Separate Go tests therefore send the same hours through the production clock resolver on both a Wednesday and a Sunday. Those cases guard against a return of the old weekday-versus-weekend split.
 
 Lean models only the part of The Lot controlled by the ranked selector. It includes the structural Hero identity so the coverage question accounts for the top card, but the Hero appears independently and does not consume a supporting-card position. The model excludes **Live Now** and other modules inserted elsewhere on the page. The theorem below establishes coverage only for cards that pass through this selector.
 


### PR DESCRIPTION
Clarifies that the five visits share one local day by construction: fiveVisitsOn copies a single localDay argument into all five records. Lean is not performing a separate check that the records agree.