### PR TITLE
Show the Lean history data flow

### DIFF
--- a/_drafts/every-card-will-show-three-pass-audit.md
+++ b/_drafts/every-card-will-show-three-pass-audit.md
@@ -5,7 +5,7 @@ Post: `_posts/2026-08-24-every-card-will-show.markdown`
 Evidence base:
 
 - Zabriskie `origin/main` at `fffec3548949bce7803dd48ad8600de9ca6e228d`.
-- Blog `origin/master` at `7747aefab9d335132973246d77388dd60da0ca36`.
+- Blog `origin/master` at `c47ce48c4e3db589fcea9f4b7692e2a5977aac21`.
 - The author's first-person account for the conversation, elapsed time, the agent's 47-item product enumeration with 20 missing, agency, repeated requirement, production timing, and Zabriskie's role as a fully vibe-coded application whose implementation code he does not read.
 
 ## Structural reader
@@ -56,6 +56,7 @@ The new subheads keep the model failure, corrected same-day representation, hist
 
 Corrections preserved from the evidence pass:
 
+- Expanded the `simulateDayFrom` excerpt to show both `go initialHistory visits`, which feeds the selected history into the first visit, and `go nextHistory rest`, which carries the updated history forward.
 - Rewrote the history explanation to distinguish the two fixed initial histories from the history that `simulateDayFrom` updates between visits; the theorems do not quantify over arbitrary history.
 - Defined `additionalPostures` in product language as additional guaranteed programs.
 - Corrected the same-day explanation: `fiveVisitsOn` reuses one `localDay` by construction; Lean is not performing a separate inequality check over the five records.

--- a/_posts/2026-08-24-every-card-will-show.markdown
+++ b/_posts/2026-08-24-every-card-will-show.markdown
@@ -184,20 +184,32 @@ def oneDayKeepsUnseen (localDay : Nat) (eventLead onTour : Bool) :
 
 `scheduledVisitsOn` maps the five fixed hours in `fiveVisitsOn` to morning, midday, afternoon, evening, and late night without throwing the hours away. `oneDayKeepsFrom` is where the starting history enters the simulation. `freshHistoryFor` constructs the one-impression case. `oneDayKeepsUnseen` instead passes `[]`, an empty history meaning that no card has been seen. `simulateDayFrom` then runs the selector five times and returns five lists of retained card names. `eventLead` and `onTour` tell it which two product conditions remain fixed during the walk.
 
-Inside `simulateDayFrom`, the transition happens in four steps:
+Inside `simulateDayFrom`, a recursive helper named `go` carries that history from one visit to the next:
 
 ```lean
-let staleness := stalenessFromHistory history
-let keep := capCards units visit.daypart isEventLead onTour
-  (capForDaypart visit.daypart) staleness
-let recorded := recordImpressions history keep
-let nextHistory :=
-  match rest with
-  | [] => recorded
-  | next :: _ => advanceHistory recorded (next.hour - visit.hour)
+def simulateDayFrom (units : List Card) (visits : List ScheduledVisit)
+    (isEventLead onTour : Bool)
+    (initialHistory : List (String × ImpressionHistory)) :
+    List (List String) :=
+  let rec go (history : List (String × ImpressionHistory))
+      (remaining : List ScheduledVisit) : List (List String) :=
+    match remaining with
+    | [] => []
+    | visit :: rest =>
+      let staleness := stalenessFromHistory history
+      let keep := capCards units visit.daypart isEventLead onTour
+        (capForDaypart visit.daypart) staleness
+      let recorded := recordImpressions history keep
+      let nextHistory :=
+        match rest with
+        | [] => recorded
+        | next :: _ =>
+          advanceHistory recorded (next.hour - visit.hour)
+      keep :: go nextHistory rest
+  go initialHistory visits
 ```
 
-`stalenessFromHistory` applies the production formula to the history at the time of the current request. `capCards` makes the selection. `recordImpressions` increments the count and resets the age of every retained card. `advanceHistory` then adds the local-hour gap before the recursive call handles the next visit.
+The final line is where the data enters the loop: `go initialHistory visits` makes the selected starting history the `history` variable for the first visit. `stalenessFromHistory history` reads it to calculate the scores used by `capCards`. After the selection, `recordImpressions` updates the counts, `advanceHistory` adds the gap before the next visit, and `go nextHistory rest` passes that updated data into the next iteration.
 
 Two more helpers turn those five outputs into the coverage question:
 


### PR DESCRIPTION
Expands the simulateDayFrom excerpt to show how initialHistory enters the recursive loop, where history is read for scoring, and how nextHistory is passed into the next visit.