### PR TITLE
Tighten the five-visit proof boundaries

### DIFF
--- a/_drafts/every-card-will-show-three-pass-audit.md
+++ b/_drafts/every-card-will-show-three-pass-audit.md
@@ -5,7 +5,7 @@ Post: `_posts/2026-08-24-every-card-will-show.markdown`
 Evidence base:
 
 - Zabriskie source excerpts rechecked through merged PR #2651 at `9a1141c2f1a8193a018e77a01e6fd7432b1fbc56`.
-- Blog `origin/master` at `fd63600bfe5dfab3e85ed4dc47614f769060830c`.
+- Blog `origin/master` at `145ce38bebd60a092a843921a6aee4c5935495ee`.
 - The author's first-person account for the conversation, elapsed time, the agent's 47-item product enumeration with 20 missing, agency, repeated requirement, production timing, and Zabriskie's role as a fully vibe-coded application whose implementation code he does not read.
 
 ## Structural reader
@@ -47,6 +47,8 @@ The new subheads keep the model failure, fixed schedule, structural coverage mec
 | Lean separates the starvation property from selector reproduction | `lean/LotLead/Starvation.lean`, `Catalog.lean`, `Cap.lean`, and `Cover.lean` at merged PR #2651 | The coverage theorem is now direct set equality. Dates, hours, history, ranking, modes, and capacity remain outside its statement. |
 | Public code excerpt matches the current Lean source | `availableCards`, `cardsAcrossFivePrograms`, and `union_of_five_programs_is_all_available_cards` from `lean/LotLead/Starvation.lean` at `9a1141c2f` | The only displayed theorem says that the union across five programs equals the available-card set. `nameSet` is explained as sorting and deduplicating the two name lists. |
 | The direct set-equality theorem holds | Local `./scripts/lean-lot-lead.sh`, PR #2651 Lean CI, unchanged differential fixtures, and focused production Go tests | Verified after replacing the indirect empty-starvation theorem. The selector twin and Go outputs did not change. |
+| `availableCards` denotes the full modeled catalog, not dynamic runtime eligibility | `Catalog.fullNames`, `Starvation.availableCards`, and the `allApplicableRankedLotCards` Go-test assumption | Added the assumption before the code excerpt so readers do not interpret the theorem as quantifying over arbitrary live eligibility changes. |
+| Direct equality is an assignment invariant, not proof of browser output | `Starvation.lean` for the union, `reservationsFit` for capacity, `Cover.lean` and differential fixtures for selector behavior, and the server-to-renderer handoff described later | Added the boundary immediately after the theorem and retained the separate implementation bridge. |
 | Lean checks coverage from two selected uniform starting histories | The all-unseen and all-fresh theorems in `lean/LotLead/Cover.lean` | Removed the history tutorial from the public post. Those finite cases are not a proof of arbitrary-history independence, and the structural coverage argument comes from reservations plus matching capacity. |
 | Go is compared through 64 deterministic trials from two histories plus a synthetic full-catalog selector test | `lot_cover_lean_diff_test.go`, `lot_card_day_coverage_test.go`, and `scripts/lean-lot-lead.sh` | Explicitly says the 128 supporting-card comparisons are sampled and that the full-catalog unit test calls the real selector without exercising the full request-to-browser path. |
 | Current browser no longer applies the old second scheduling policy | `lotApplyCardCap` and `lotRankCards` in `backend/internal/handlers/lot_posture.go`; `serverOwnsLayout` and `applyServerModuleOrder` in `web/src/components/sdui/cinematic/CinematicLot.jsx`; `docs/lot-posture-audit.md` | Separates server-owned candidate construction and layout from the checked selector. Preserves explicit client dismissals and does not claim proof of rendered pixels. |

--- a/_posts/2026-08-24-every-card-will-show.markdown
+++ b/_posts/2026-08-24-every-card-will-show.markdown
@@ -107,7 +107,7 @@ This is where formal verification, using mathematical proof to check a software 
 
 ### The proof was still too complicated
 
-Fixing the impossible day did not fix the shape of the proof. The next version still ran a production-like selector inside the coverage theorem. It carried a `localDay` value that Lean never used to choose a program, checked two viewing histories even though history only changed filler order, and ran four fixed event and tour combinations. All of that was real implementation behavior. None of it was the starvation invariant.
+Fixing the impossible day did not fix the shape of the proof. The next version still ran a production-like selector inside the coverage theorem. It carried a `localDay` value that did not influence which program Lean chose, checked two viewing histories even though history could change order and filler but not which cards had reserved room, and ran four fixed event and tour combinations. All of that was real implementation behavior. None of it was the starvation invariant.
 
 I only pulled those pieces apart while editing this post. I kept asking what each input did and why five unexplained capacities appeared inside the argument. The theorem was valid for the executions it modeled, but the agent had reproduced the machinery around my question instead of stating the question simply enough for me to audit.
 
@@ -119,9 +119,9 @@ That is the theorem we should have written first. I had the agent replace the ol
 
 ### The theorem we actually needed
 
-The repaired product has five programs every day: morning, midday, afternoon, evening, and late night. A separate Go test sends five corresponding times on both a Wednesday and a Sunday through the production clock. That is where we check that the programs can occur on one date. The Lean coverage theorem does not need a date or an hour.
+The repaired product defines the same five programs every day: morning, midday, afternoon, evening, and late night. A separate Go test sends five local times through the production hour-to-program resolver on a representative weekday and weekend date. On each date, those five visits must produce the full sequence. The Lean coverage theorem does not need a date or an hour.
 
-The model collects the cards reserved in each of those programs, adds the structural Hero that is always present, and compares that union with the catalog. `nameSet` sorts the names and removes duplicates so the two lists represent sets:
+For this theorem, `availableCards` means the full modeled catalog under the assumption that every card has the content required to render. It is not the changing set of cards eligible in a live request. The model collects the cards reserved in each program, adds the structural Hero that is always present, and compares that union with the catalog. `nameSet` sorts the names and removes duplicates so the two lists represent sets:
 
 ```lean
 def availableCards : List String :=
@@ -135,15 +135,15 @@ theorem union_of_five_programs_is_all_available_cards :
   native_decide
 ```
 
-That is the coverage claim. **Connections** is reserved in two programs, but set equality removes the duplicate and only requires the card to appear once. **Live Now** and other uncapped modules are outside this selector.
+`native_decide` evaluates this finite equality and turns the result into a checked proof. **Connections** is reserved in two programs, but set equality removes the duplicate and only requires the card to appear once. **Live Now** and other uncapped modules are outside this selector.
 
-A separate theorem checks that each program has enough room for its reservations. The more detailed model handles history, scoring, ordering, and modes so it can be compared with Go. Those are useful checks, but they no longer obscure the finite claim Lean is proving about the current catalog.
+This is the assignment invariant, not yet a proof of what reached the browser. A separate theorem checks that each program has enough room for its reservations. The more detailed model handles history, scoring, ordering, and modes so it can be compared with Go. Those checks connect the small theorem to the implementation without putting the implementation back inside the theorem.
 
 ### Connecting Lean back to Go
 
 But did the Go code make the same decisions as the model?
 
-This is where the additional model detail matters. The production selector still contains scoring and ordering rules, even though starvation should not depend on them. The Lean twin reproduces those rules so a change in Go cannot silently move the reservation pass or make an assigned card lose to filler.
+This is where the additional model detail matters. The production selector still contains scoring and ordering rules, even though starvation should not depend on them. The Lean twin reproduces those rules so the compared cases fail if Go moves the reservation pass or lets an assigned card lose to filler.
 
 The supporting-card selector has far too many possible input catalogs to compare exhaustively. Instead, Lean writes a fixed sample of 128 selector walks, including the complete modeled catalog and reproducible subsets across the four event-lead and tour configurations. That number is a chosen test budget, not a total derived from the model.
 


### PR DESCRIPTION
## Summary

Applies an adversarial pass to the five-visit repair section. It now distinguishes the full modeled catalog from dynamic live eligibility, states that direct set equality is an assignment invariant rather than proof of browser output, narrows the history claim, describes the Go check as the hour-to-program boundary it actually tests, explains `native_decide`, and limits the selector-twin claim to the cases actually compared.

The editorial audit records the revised claim boundaries.

## Verification

- Rechecked the direct theorem against Zabriskie `origin/main` at `9a1141c2f`
- Rechecked the production daypart resolver and Wednesday/Sunday Go test
- `git diff --check`
- Jekyll production build
- Continuous rendered read of the revised Lean sequence