### PR TITLE
Retitle draft: The Quickest Path to a Diff

### DIFF
--- a/_drafts/the-quickest-path-to-a-diff.markdown
+++ b/_drafts/the-quickest-path-to-a-diff.markdown
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Local Reasoning"
+title:  "The Quickest Path to a Diff"
 subtitle: "The app died at Red Rocks while its health checks stayed green. Every line of code was fine. The sum was nobody's job."
 date:   2026-08-31 02:00:00 -0400
 group: ai


### PR DESCRIPTION
Author's pick from the title candidates. Front-matter title updated and the draft file renamed to `_drafts/the-quickest-path-to-a-diff.markdown` so the slug matches at publish time. Subtitle unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_019vFuBZdgpzgR918wB4NgYd)_