### PR TITLE
Compact blog navigation and use a CV icon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -74,7 +74,9 @@
                 <a href="/research.html">research</a>
                 <a href="/teaching.html">teaching</a>
                 <a href="/publications.html">publications</a>
-                <a href="/meiklejohn-cv.pdf">cv</a>
+                <a class="site-nav-icon" href="/meiklejohn-cv.pdf" aria-label="CV (PDF)" title="CV (PDF)">
+                  <svg class="site-nav-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M14 3H6a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8z"/><path d="M14 3v5h5M9 12h6M9 16h6"/></svg>
+                </a>
                 {% if site.social.github %}
                 <a class="site-nav-icon site-nav-github" href="{{ site.social.github }}" aria-label="GitHub (code)">
                   <svg class="site-nav-icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>

--- a/css/main.css
+++ b/css/main.css
@@ -522,7 +522,7 @@ code {
   flex-wrap: wrap;
   align-items: flex-end;
   justify-content: space-between;
-  gap: 1rem 2rem;
+  gap: 0.75rem 1.25rem;
   margin-bottom: 2rem;
   padding-bottom: 1.1rem;
   border-bottom: 1px solid var(--border);
@@ -555,11 +555,11 @@ code {
 .site-nav {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: center;
   justify-content: flex-end;
-  gap: 0.35rem 1.1rem;
+  gap: 0.3rem 0.65rem;
   font-family: var(--font-ui);
-  font-size: 0.84rem;
+  font-size: 0.74rem;
   font-weight: 400;
 }
 
@@ -591,8 +591,8 @@ code {
 
 .site-nav-icon-svg {
   display: block;
-  width: 1.15rem;
-  height: 1.15rem;
+  width: 1em;
+  height: 1em;
 }
 
 .site-main {
@@ -1396,8 +1396,8 @@ html {
 
   .site-nav {
     justify-content: flex-start;
-    gap: 0.4rem 0.4rem;
-    font-size: 0.8rem;
+    gap: 0.25rem 0.3rem;
+    font-size: 0.7rem;
     line-height: 1.3;
   }
 
@@ -1975,4 +1975,8 @@ html {
     flex-direction: column;
     align-items: stretch;
   }
+}
+
+@media (max-width: 360px) {
+  .site-nav { column-gap: 0.15rem; }
 }


### PR DESCRIPTION
Makes the header navigation smaller and more tightly spaced, with proportionally sized icons. Replaces the CV text with a document icon carrying an accessible CV (PDF) label and tooltip.

Validation: Jekyll build and whitespace checks passed. Browser checked single-row navigation and no horizontal overflow at phone widths, plus desktop alignment. Links retain keyboard focus styling and mobile vertical hit areas.
